### PR TITLE
feat: harden public skill onboarding

### DIFF
--- a/examples/public-skills/notes-snapshot-control-room/README.md
+++ b/examples/public-skills/notes-snapshot-control-room/README.md
@@ -5,6 +5,7 @@ backup control room.
 
 ## What this skill teaches an agent
 
+- how to acquire `notesctl` from a public checkout or reuse an existing one
 - how to prove the operator lane before touching builder surfaces
 - how to wire `notesctl mcp` into a local host
 - how to separate AI Diagnose, Local Web API, and MCP into honest lanes
@@ -14,7 +15,8 @@ backup control room.
 
 1. Read `SKILL.md`
 2. Open `references/install-and-attach.md`
-3. Run the proof path from `references/usage-and-proof.md`
+3. Acquire `notesctl`, then run the proof path from
+   `references/usage-and-proof.md`
 4. Only then attach the MCP lane or explain host-specific boundaries
 
 ## Demo / proof links
@@ -24,6 +26,24 @@ backup control room.
 - Proof page: https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/
 - MCP guide: https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/
 - For Agents: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/
+
+## Visual demo
+
+![Apple Notes Snapshot first-success run flow](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-snapshot/main/assets/readme/run-flow.gif)
+
+- Quick visual proof:
+  the skill now points to a concrete run-flow demo, not just prose-only setup
+  instructions.
+
+## MCP capability surface
+
+- Post-attach checks:
+  `get_status`, `run_doctor`, `verify_freshness`, `get_log_health`,
+  `list_recent_runs`, and `get_access_policy`
+- First resource to read back:
+  `notes-snapshot://recent-runs`
+- Boundary:
+  local stdio only, read-only-first tools/resources, and no hosted runtime
 
 ## Best fit
 

--- a/examples/public-skills/notes-snapshot-control-room/SKILL.md
+++ b/examples/public-skills/notes-snapshot-control-room/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: notes-snapshot-control-room
 description: This skill should be used when the user asks to "connect Apple Notes Snapshot to a host", "run notesctl mcp", "diagnose why Apple Notes Snapshot failed to attach", "separate AI Diagnose from MCP", or "verify the control-room proof path". It teaches local preflight, MCP wiring, capability boundaries, and proof-first usage without turning the repo into a hosted platform.
-version: 1.0.1
+version: 1.0.2
 triggers:
   - notesctl mcp
   - apple notes snapshot
@@ -19,6 +19,8 @@ rewriting it into a hosted AI platform or a generic assistant product.
 
 ## What this skill teaches
 
+- how to acquire `notesctl` from a public checkout when the host does not
+  already have it
 - how to prove the local control room before touching builder surfaces
 - how to wire `notesctl mcp` into a host without pretending there is a remote
   service
@@ -36,16 +38,27 @@ rewriting it into a hosted AI platform or a generic assistant product.
 
 ## First-success flow
 
-1. Prove the operator lane first:
+1. Acquire `notesctl` first using `references/install-and-attach.md`.
+2. Prove the operator lane first:
    - `./notesctl run --no-status`
    - `./notesctl install --minutes 30 --load`
    - `./notesctl verify`
    - `./notesctl doctor`
-2. Only after local state exists, attach the builder lane:
+3. Only after local state exists, attach the builder lane:
    - `./notesctl ai-diagnose`
    - `./notesctl web`
    - `./notesctl mcp`
-3. Keep host proof separate from repo proof.
+4. Keep host proof separate from repo proof.
+
+## MCP capability surface
+
+- post-attach host checks should see `get_status`, `run_doctor`,
+  `verify_freshness`, `get_log_health`, `list_recent_runs`, and
+  `get_access_policy`
+- the repo also documents the `notes-snapshot://recent-runs` resource as a
+  first read-back surface
+- boundary:
+  local stdio only, read-only-first tools/resources, and no hosted runtime
 
 ## Preflight before any attach claim
 

--- a/examples/public-skills/notes-snapshot-control-room/manifest.yaml
+++ b/examples/public-skills/notes-snapshot-control-room/manifest.yaml
@@ -4,7 +4,7 @@ artifact: public-skill-listing-manifest
 skill:
   name: notes-snapshot-control-room
   display_name: Apple Notes Snapshot Control-Room
-  version: 1.0.1
+  version: 1.0.2
   entrypoint: SKILL.md
   package_shape: skill-folder
 
@@ -12,7 +12,7 @@ registry_targets:
   clawhub:
     status: ready-but-not-listed
     package_shape: skill-folder
-    submit_via: clawhub publish <repo-root>/examples/public-skills/notes-snapshot-control-room --slug notes-snapshot-control-room --name "Apple Notes Snapshot Control-Room" --version 1.0.1 --tags apple-notes,local-first,backup,mcp
+    submit_via: clawhub publish <repo-root>/examples/public-skills/notes-snapshot-control-room --slug notes-snapshot-control-room --name "Apple Notes Snapshot Control-Room" --version 1.0.2 --tags apple-notes,local-first,backup,mcp
   openhands-extensions:
     status: folder-ready
     package_shape: skill-folder

--- a/examples/public-skills/notes-snapshot-control-room/references/install-and-attach.md
+++ b/examples/public-skills/notes-snapshot-control-room/references/install-and-attach.md
@@ -6,6 +6,20 @@ Use this reference when the agent or reviewer asks:
 - what exact command should the host run?
 - what has to be proven before attach claims?
 
+## Get `notesctl` first
+
+If the host does not already have a checkout with `notesctl`, start from a
+public repo checkout:
+
+```bash
+git clone --depth 1 --branch v0.1.12 \
+  https://github.com/xiaojiou176-open/apple-notes-snapshot.git
+cd apple-notes-snapshot
+```
+
+If you want current-main behavior instead of the last tagged proof baseline,
+clone without `--branch v0.1.12`.
+
 ## Minimum operator proof
 
 Before any host attach claim, prove the operator lane first:
@@ -43,11 +57,26 @@ For a generic MCP host that expects `command` plus `args`, use:
 
 Replace `/absolute/path/to/notesctl` with the path for the local checkout.
 
+For example:
+
+- `/absolute/path/to/apple-notes-snapshot/notesctl`
+- `/path/to/apple-notes-snapshot/notesctl`
+
 ## Builder surfaces that pair with this skill
 
 - AI Diagnose: `./notesctl ai-diagnose`
 - Local Web API: `./notesctl web`
 - MCP Provider: `./notesctl mcp`
+
+## MCP capability surface after attach
+
+- `get_status`
+- `run_doctor`
+- `verify_freshness`
+- `get_log_health`
+- `list_recent_runs`
+- `get_access_policy`
+- `notes-snapshot://recent-runs`
 
 These three surfaces are not interchangeable:
 

--- a/examples/public-skills/notes-snapshot-control-room/references/usage-and-proof.md
+++ b/examples/public-skills/notes-snapshot-control-room/references/usage-and-proof.md
@@ -8,7 +8,15 @@ Use this reference when the reviewer asks:
 
 ## First-success path
 
-The shortest truthful path is:
+Acquire the tool first if needed:
+
+```bash
+git clone --depth 1 --branch v0.1.12 \
+  https://github.com/xiaojiou176-open/apple-notes-snapshot.git
+cd apple-notes-snapshot
+```
+
+Then run the shortest truthful path:
 
 ```bash
 ./notesctl run --no-status
@@ -26,6 +34,17 @@ Then, if the local state exists, move into builder surfaces:
 ./notesctl mcp
 ```
 
+## MCP capability surface after attach
+
+- Tools:
+  `get_status`, `run_doctor`, `verify_freshness`, `get_log_health`,
+  `list_recent_runs`, and `get_access_policy`
+- Resource:
+  `notes-snapshot://recent-runs`
+- Boundary:
+  the MCP lane is local stdio, read-only-first, and backed by the same
+  repo-owned state as the operator lane
+
 ## Example prompts
 
 - "Is this Apple Notes Snapshot problem a local preflight failure or an MCP attach failure?"
@@ -41,6 +60,10 @@ Then, if the local state exists, move into builder surfaces:
 - MCP provider guide: https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/
 - For Agents overview: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/
 - Public skills pack docs: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/public-skills/
+
+## Visual demo
+
+![Apple Notes Snapshot run flow](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-snapshot/main/assets/readme/run-flow.gif)
 
 ## Reviewer one-liner
 

--- a/tests/unit/test_registry_lane_unit.py
+++ b/tests/unit/test_registry_lane_unit.py
@@ -29,7 +29,7 @@ class RegistryLaneUnitTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("name: notes-snapshot-control-room", skill_text)
         self.assertIn("description:", skill_text)
-        self.assertIn("version: 1.0.1", skill_text)
+        self.assertIn("version: 1.0.2", skill_text)
 
     def test_public_skill_listing_manifest_is_present_and_truthful(self):
         manifest_text = (
@@ -42,7 +42,7 @@ class RegistryLaneUnitTests(unittest.TestCase):
         self.assertIn("artifact: public-skill-listing-manifest", manifest_text)
         self.assertIn("name: notes-snapshot-control-room", manifest_text)
         self.assertIn('display_name: Apple Notes Snapshot Control-Room', manifest_text)
-        self.assertIn("version: 1.0.1", manifest_text)
+        self.assertIn("version: 1.0.2", manifest_text)
         self.assertIn("status: ready-but-not-listed", manifest_text)
         self.assertIn("No live ClawHub listing exists yet", manifest_text)
         self.assertRegex(
@@ -50,7 +50,7 @@ class RegistryLaneUnitTests(unittest.TestCase):
             re.compile(
                 r"submit_via: clawhub publish <repo-root>/examples/public-skills/notes-snapshot-control-room "
                 r"--slug notes-snapshot-control-room --name \"Apple Notes Snapshot Control-Room\" "
-                r"--version 1.0.1 --tags apple-notes,local-first,backup,mcp"
+                r"--version 1.0.2 --tags apple-notes,local-first,backup,mcp"
             ),
         )
         self.assertIn("references/install-and-attach.md", manifest_text)


### PR DESCRIPTION
## Summary
- add a public acquisition lane for `notesctl` so the public skill no longer assumes an existing checkout
- add visual demo links and exact post-attach MCP capability surface guidance
- bump the ClawHub-facing public skill packet to 1.0.2 and update the registry-lane unit test

## Verification
- `./.runtime-cache/dev/venv/bin/python -m unittest tests.unit.test_registry_lane_unit`