### PR TITLE
[codex] reland operator control room second pass (xiao)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ can inspect the same local backup state without turning the workflow into a
 hosted service.
 
 [Start the 3-step quickstart](https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/) |
+[First-run troubleshooting](https://xiaojiou176-open.github.io/apple-notes-snapshot/troubleshooting/) |
+[Open the proof page](https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/) |
 [Compare with upstream](https://xiaojiou176-open.github.io/apple-notes-snapshot/compare/) |
 [Browse release history](https://xiaojiou176-open.github.io/apple-notes-snapshot/releases/) |
-[Open the proof page](https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/) |
 [Get support or routing help](https://xiaojiou176-open.github.io/apple-notes-snapshot/support/)
 
 [![Trusted CI](https://github.com/xiaojiou176-open/apple-notes-snapshot/actions/workflows/trusted-ci.yml/badge.svg)](https://github.com/xiaojiou176-open/apple-notes-snapshot/actions/workflows/trusted-ci.yml)
@@ -29,6 +30,8 @@ hosted service.
   Use `launchd` to schedule repeatable snapshots instead of babysitting manual exports.
 - **See health before you guess**
   Check freshness, failure reasons, logs, and recovery clues when the loop drifts.
+- **Read the next safe move first**
+  The Web console now surfaces an operator focus deck above the raw transcript so you can see the next move, the reason, and the reading order before diving into action output.
 
 > Category: local-first Apple Notes backup control room.
 > AI/agent hook: AI-assisted diagnostics plus a token-gated Local Web API and
@@ -53,7 +56,26 @@ If you want the shortest public evidence trail after that first pass, open the
 It collects the repo-owned gates, the GitHub-controlled release and Pages
 evidence, and the current same-machine boundary in one place.
 
-## Current lane order
+## Start with Run -> Install -> Verify
+
+Treat the first healthy loop like a three-stop checklist, not like a dashboard
+to decode all at once.
+
+1. **Run**
+   Use `./notesctl run --no-status` once so macOS can surface permissions and
+   the local ledger can record a first successful baseline.
+2. **Install**
+   Use `./notesctl install --minutes 30 --load` after that first run so the
+   workflow becomes a repeatable `launchd` loop instead of a manual chore.
+3. **Verify**
+   Use `./notesctl verify` first, then `./notesctl doctor` only if warnings or
+   empty state remain.
+
+After that verified loop exists, the Web console, proof page, AI Diagnose,
+Local Web API, and MCP surfaces become much easier to read because they are all
+describing a baseline you already proved.
+
+## Builder and maintainer lanes after the operator path
 
 Treat Apple Notes Snapshot like a local control room with a few adapter boxes
 around it:
@@ -182,12 +204,14 @@ clear snapshot paths, and easier recovery when something fails.
 
 ## What the Web console shows
 
-The local Web console is optional, but it is the fastest way to understand what
-the workflow is doing at a glance.
+The local Web console is optional, and it makes the most sense after you have
+already completed the first `run -> install -> verify` pass. Use it to watch
+the loop you just proved, not as a replacement for that first proof.
 
 It surfaces:
 
 - snapshot health, last success, launchd state, and failure reason
+- an operator focus deck that says what to do next and which panel to open first
 - doctor warnings and dependency readiness
 - recent metrics and trigger sources
 - log-health summaries

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,8 +53,9 @@
         </div>
         <div class="site-nav__links">
           <a href="./quickstart/">Quickstart</a>
-          <a href="./compare/">Compare</a>
+          <a href="./troubleshooting/">Troubleshooting</a>
           <a href="./proof/">Proof</a>
+          <a href="./compare/">Compare</a>
           <a href="./releases/">Releases</a>
           <a href="./support/">Support</a>
           <a href="https://github.com/xiaojiou176-open/apple-notes-snapshot">GitHub</a>
@@ -72,30 +73,35 @@
             `launchd` scheduling, visible health checks, and a calmer recovery path when something drifts.
           </p>
           <p>
-            Start with the 3-step operator quickstart, compare it to upstream if you need context,
-            and only then open AI Diagnose, the Local Web API, or the read-only MCP lane. Those
-            builder surfaces are real, but they should feel like an upgrade path, not the first puzzle.
+            Start with one successful run, install the scheduler, then verify the loop before
+            you read deeper telemetry. The Web console, proof page, AI Diagnose, the Local Web API,
+            and the read-only MCP lane are real, but they should feel like second shelves after the
+            operator contract already clicks.
+          </p>
+          <p>
+            The console now leads with an operator focus deck before the raw action transcript, so
+            the next safe move and the reading order stay visible when the loop drifts.
           </p>
         <div class="cta-row">
           <a class="btn btn--primary" href="./quickstart/">Start the 3-step quickstart</a>
+          <a class="btn btn--secondary" href="./troubleshooting/">First-run troubleshooting</a>
           <a class="btn btn--secondary" href="./proof/">Open the proof page</a>
-          <a class="btn btn--secondary" href="./compare/">Compare with upstream</a>
         </div>
           <div class="hero-curation">
             <article class="curation-card">
-              <span class="eyebrow-inline">3-minute proof</span>
-              <strong>Confirm the local loop before you touch anything fancier.</strong>
-              <p>One run, one install, one verify pass: that is enough to prove the path, the scheduler, and the health surface.</p>
+              <span class="eyebrow-inline">Step 1</span>
+              <strong>Run one snapshot and let macOS show the real permission prompts.</strong>
+              <p>Build a first successful baseline before you ask the project to explain anything more complicated.</p>
             </article>
             <article class="curation-card">
-              <span class="eyebrow-inline">Visible by design</span>
-              <strong>See the status, proof, and recovery story without guessing.</strong>
-              <p>The same control room shows destination, freshness, launchd state, logs, and recovery clues instead of hiding them in scripts.</p>
+              <span class="eyebrow-inline">Step 2</span>
+              <strong>Install the loop so backups stop depending on your memory.</strong>
+              <p>Use the built-in `launchd` lane once the first run works, then let the control room keep the rhythm visible.</p>
             </article>
             <article class="curation-card">
-              <span class="eyebrow-inline">Builder second lane</span>
-              <strong>Bring AI, Web, and MCP in only after the operator story clicks.</strong>
-              <p>The repo still ships AI Diagnose, the Local Web API, and the read-only MCP lane, but none of them are allowed to outrun the operator contract.</p>
+              <span class="eyebrow-inline">Step 3</span>
+              <strong>Verify the loop, then open proof and diagnostics with context.</strong>
+              <p>Once `verify` passes, the status, logs, proof page, and builder surfaces describe a loop you already proved instead of a mystery you still need to solve.</p>
             </article>
           </div>
           <div class="hero__stats">
@@ -108,8 +114,8 @@
               Review the path, run one snapshot, then install and verify the loop.
             </div>
             <div class="hero__stat">
-              <strong>1 proof page</strong>
-              The shortest external audit path lives on one page instead of across scattered notes.
+              <strong>2 support pages</strong>
+              Quickstart gets you moving and troubleshooting catches first-run snags before you drown in telemetry.
             </div>
             <div class="hero__stat">
               <strong>Builder later</strong>
@@ -149,6 +155,14 @@
             <p>
               `status`, `verify`, `doctor`, log rotation, and metrics make the workflow
               observable instead of mysterious.
+            </p>
+          </article>
+          <article class="card">
+            <span class="eyebrow-inline">Operator guidance</span>
+            <h3>Read the next move before you read raw output.</h3>
+            <p>
+              The control room now puts a next-step deck above the transcript so operators can
+              verify the right panel order before they trigger another fix.
             </p>
           </article>
           <article class="card">
@@ -214,8 +228,8 @@
 
       <section class="section">
         <div class="section__header">
-          <span class="section__eyebrow">Go deeper</span>
-          <h2>Open the next shelf only after Quickstart, Compare, and Proof make sense.</h2>
+          <span class="section__eyebrow">After the first verified loop</span>
+          <h2>Open the next shelf only after Run, Install, and Verify already make sense.</h2>
         </div>
         <div class="cards cards--routes">
           <article class="card card--accent">
@@ -224,19 +238,19 @@
             <p><a href="./troubleshooting/">Open troubleshooting</a></p>
           </article>
           <article class="card">
+            <h3>Compare with upstream</h3>
+            <p>Read this next when you want product context for why this repo adds scheduling, health checks, and a calmer control room.</p>
+            <p><a href="./compare/">Open compare</a></p>
+          </article>
+          <article class="card">
             <h3>Release history</h3>
             <p>Read the tagged public story version by version when you want release truth instead of workshop notes.</p>
             <p><a href="./releases/">Browse release history</a></p>
           </article>
           <article class="card card--warm">
             <h3>For Agents</h3>
-            <p>Open the builder shelf only after the control-room contract is clear and you want the truthful Web, AI, or MCP split.</p>
+            <p>Open the builder shelf last, after the control-room contract is clear and you want the truthful Web, AI, or MCP split.</p>
             <p><a href="./for-agents/">Open the builder lane</a></p>
-          </article>
-          <article class="card">
-            <h3>Support and community</h3>
-            <p>Use the routing pages when you need the right lane for Q&amp;A, ideas, workflow sharing, or announcements.</p>
-            <p><a href="./support/">Support</a> | <a href="./community/">Community</a></p>
           </article>
         </div>
       </section>

--- a/tests/unit/test_web_i18n_contract.py
+++ b/tests/unit/test_web_i18n_contract.py
@@ -11,6 +11,25 @@ class WebI18nContractTests(unittest.TestCase):
         self.assertIn("Object.create(null)", content)
         self.assertIn('Object.freeze(["__proto__", "constructor", "prototype"])', content)
 
+    def test_operator_focus_nodes_are_wired_into_bilingual_contract(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        html = (repo_root / "web" / "index.html").read_text(encoding="utf-8")
+        i18n = (repo_root / "web" / "i18n.js").read_text(encoding="utf-8")
+
+        self.assertIn('data-i18n="ui.operatorFocusDeck"', html)
+        self.assertIn('data-i18n="ui.currentNextMove"', html)
+        self.assertIn('data-i18n="ui.readOrder"', html)
+        self.assertIn('data-i18n="ui.controlRoomSignals"', html)
+        self.assertIn('data-i18n="ui.latestActionTranscript"', html)
+        self.assertIn('data-i18n="message.operatorFocusDeckSummary"', html)
+        self.assertIn('data-i18n="message.outputGuidanceSummary"', html)
+        self.assertIn('data-i18n="message.outputMetaHint"', html)
+
+        self.assertIn('operatorFocusDeck: "Operator Focus Deck"', i18n)
+        self.assertIn('operatorFocusDeck: "操作员聚焦甲板"', i18n)
+        self.assertIn('outputGuidanceSummary:', i18n)
+        self.assertIn('focusWaitingSignals:', i18n)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/web/app.js
+++ b/web/app.js
@@ -31,8 +31,11 @@ const connection = $("connection-status");
 const outputPane = $("action-output");
 const actionAnnouncer = $("action-announcer");
 const outputPill = $("output-pill");
+const outputContext = $("output-context");
+const outputGuidance = $("output-guidance");
 const actionsPill = $("actions-pill");
 const accessPill = $("access-pill");
+const operatorFocusPill = $("operator-focus-pill");
 const metricsFilterInput = $("metrics-run-id");
 const localeSwitcher = $("locale-switcher");
 
@@ -48,6 +51,77 @@ const uiState = {
   bannerKey: "",
   renderedLocale: null,
 };
+
+function getOperatorFocusCopy(locale) {
+  return {
+    signalsWaiting: "message.focusWaitingSignals",
+    reconnect: {
+      next: "message.focusReconnectNext",
+      reason: "message.focusReconnectReason",
+      readOrder: "message.focusReconnectReadOrder",
+      guidance: "message.focusReconnectGuidance",
+    },
+    readonly: {
+      next: "message.focusReadonlyNext",
+      reason: "message.focusReadonlyReason",
+      readOrder: "message.focusReadonlyReadOrder",
+      guidance: "message.focusReadonlyGuidance",
+    },
+    firstRun: {
+      next: "message.focusFirstRunNext",
+      reason: "message.focusFirstRunReason",
+      readOrder: "message.focusFirstRunReadOrder",
+      guidance: "message.focusFirstRunGuidance",
+    },
+    install: {
+      next: "message.focusInstallNext",
+      reason: "message.focusInstallReason",
+      readOrder: "message.focusInstallReadOrder",
+      guidance: "message.focusInstallGuidance",
+    },
+    verify: {
+      next: "message.focusVerifyNext",
+      reason: "message.focusVerifyReason",
+      readOrder: "message.focusVerifyReadOrder",
+      guidance: "message.focusVerifyGuidance",
+    },
+    recoveryWatch: {
+      next: "message.focusRecoveryWatchNext",
+      reason: "message.focusRecoveryWatchReason",
+      readOrder: "message.focusRecoveryWatchReadOrder",
+      guidance: "message.focusRecoveryWatchGuidance",
+    },
+    steady: {
+      next: "message.focusSteadyNext",
+      reason: "message.focusSteadyReason",
+      readOrder: "message.focusSteadyReadOrder",
+      guidance: "message.focusSteadyGuidance",
+    },
+    signalHealth: "message.focusSignalHealthLevel",
+    signalLaunchd: "message.focusSignalLaunchdState",
+    signalAttention: "message.focusSignalRecentAttention",
+    signalDoctorWarnings: "message.focusSignalDoctorWarnings",
+    signalAccessMode: "message.focusSignalAccessMode",
+    accessReadonly: "message.focusAccessReadonly",
+    accessActive: "message.focusAccessActive",
+    outputWaiting: {
+      context: "message.outputWaitingContext",
+      guidance: "message.outputWaitingGuidance",
+    },
+    outputFirstRun: {
+      context: "message.outputFirstRunContext",
+      guidance: "message.outputFirstRunGuidance",
+    },
+    outputFailure: {
+      context: "message.outputFailureContext",
+      guidance: "message.outputFailureGuidance",
+    },
+    outputSteady: {
+      context: "message.outputSteadyContext",
+      guidance: "message.outputSteadyGuidance",
+    },
+  };
+}
 
 function authHeaders() {
   if (!authToken) return {};
@@ -457,7 +531,7 @@ function renderOnboarding(data) {
   setPill(pill, "ONBOARDING");
   summary.textContent = i18n.t("message.firstRunExplanation");
   steps.innerHTML = "";
-  ["onboarding.stepRun", "onboarding.stepVerify", "onboarding.stepDoctor"].forEach((key) => {
+  ["onboarding.stepRun", "onboarding.stepInstall", "onboarding.stepVerify"].forEach((key) => {
     const li = document.createElement("li");
     li.textContent = i18n.t(key);
     steps.appendChild(li);
@@ -644,6 +718,126 @@ function renderAccess(data) {
     li.textContent = localizeActionName(action);
     list.appendChild(li);
   });
+}
+
+function renderOperatorFocus(status, recentRuns, doctor, access) {
+  const nextStepEl = $("operator-focus-next-step");
+  const reasonEl = $("operator-focus-reason");
+  const readOrderEl = $("operator-focus-read-order");
+  const guidanceEl = $("operator-focus-guidance");
+  const signalsEl = $("operator-focus-signals");
+  if (!nextStepEl || !reasonEl || !readOrderEl || !guidanceEl || !signalsEl) return;
+
+  const summary = recentRuns?.summary || {};
+  const ledgerStatus = status?.state_layers?.ledger?.status || "";
+  const launchdState = status?.state_layers?.launchd?.status || status?.launchd || "";
+  const healthLevel = String(status?.health_level || "").toUpperCase();
+  const doctorWarnings = Array.isArray(doctor?.warnings) ? doctor.warnings.length : 0;
+  const accessMode = access?.readonly ? "readonly" : "active";
+  const copy = getOperatorFocusCopy(i18n.getLocale());
+  const localizedHealthLevel = healthLevel
+    ? i18n.translateDisplay("healthLevel", healthLevel) || healthLevel
+    : i18n.t("common.unknown");
+  const localizedLaunchdState = launchdState
+    ? i18n.translateStateLayerStatus(launchdState) || launchdState
+    : i18n.t("common.unknown");
+  const signals = [];
+
+  let tone = "warn";
+  let nextStep = i18n.t(copy.reconnect.next);
+  let reason = i18n.t(copy.reconnect.reason);
+  let readOrder = i18n.t(copy.reconnect.readOrder);
+  let guidance = i18n.t(copy.reconnect.guidance);
+
+  if (status) {
+    if (accessMode === "readonly") {
+      nextStep = i18n.t(copy.readonly.next);
+      reason = i18n.t(copy.readonly.reason);
+      readOrder = i18n.t(copy.readonly.readOrder);
+      guidance = i18n.t(copy.readonly.guidance);
+    } else if (!status.last_success_iso || ledgerStatus === "needs_first_run") {
+      nextStep = i18n.t(copy.firstRun.next);
+      reason = i18n.t(copy.firstRun.reason);
+      readOrder = i18n.t(copy.firstRun.readOrder);
+      guidance = i18n.t(copy.firstRun.guidance);
+    } else if (launchdState === "not_loaded") {
+      nextStep = i18n.t(copy.install.next);
+      reason = i18n.t(copy.install.reason);
+      readOrder = i18n.t(copy.install.readOrder);
+      guidance = i18n.t(copy.install.guidance);
+    } else if (healthLevel === "FAIL" || ledgerStatus === "stale" || status.failure_reason) {
+      tone = "fail";
+      nextStep = i18n.t(copy.verify.next);
+      reason = i18n.t(copy.verify.reason);
+      readOrder = i18n.t(copy.verify.readOrder);
+      guidance = i18n.t(copy.verify.guidance);
+    } else if (summary.attention_state === "failure_cluster" || summary.attention_state === "recovery_watch") {
+      nextStep = i18n.t(copy.recoveryWatch.next);
+      reason = i18n.t(copy.recoveryWatch.reason);
+      readOrder = i18n.t(copy.recoveryWatch.readOrder);
+      guidance = i18n.t(copy.recoveryWatch.guidance);
+    } else {
+      tone = "ok";
+      nextStep = i18n.t(copy.steady.next);
+      reason = i18n.t(copy.steady.reason);
+      readOrder = i18n.t(copy.steady.readOrder);
+      guidance = i18n.t(copy.steady.guidance);
+    }
+
+    signals.push(i18n.t(copy.signalHealth, { value: localizedHealthLevel || i18n.t("common.unknown") }));
+    signals.push(i18n.t(copy.signalLaunchd, { value: localizedLaunchdState || i18n.t("common.unknown") }));
+    signals.push(i18n.t(copy.signalAttention, { value: summary.attention_state || i18n.t("common.none") }));
+    signals.push(i18n.t(copy.signalDoctorWarnings, { count: doctorWarnings }));
+    signals.push(
+      i18n.t(copy.signalAccessMode, {
+        value: i18n.t(accessMode === "readonly" ? copy.accessReadonly : copy.accessActive),
+      })
+    );
+  }
+
+  nextStepEl.textContent = nextStep;
+  reasonEl.textContent = reason;
+  readOrderEl.textContent = readOrder;
+  guidanceEl.textContent = guidance;
+  setSubPill(operatorFocusPill, nextStep, tone === "ok" ? "" : tone);
+
+  signalsEl.innerHTML = "";
+  if (!signals.length) {
+    const li = document.createElement("li");
+    li.textContent = i18n.t(copy.signalsWaiting);
+    signalsEl.appendChild(li);
+  } else {
+    signals.forEach((item) => {
+      const li = document.createElement("li");
+      li.textContent = item;
+      signalsEl.appendChild(li);
+    });
+  }
+}
+
+function renderOutputMeta(status, recentRuns) {
+  if (!outputContext || !outputGuidance) return;
+  const copy = getOperatorFocusCopy(i18n.getLocale());
+  if (!status) {
+    outputContext.textContent = i18n.t(copy.outputWaiting.context);
+    outputGuidance.textContent = i18n.t(copy.outputWaiting.guidance);
+    return;
+  }
+
+  if (!status.last_success_iso || status.state_layers?.ledger?.status === "needs_first_run") {
+    outputContext.textContent = i18n.t(copy.outputFirstRun.context);
+    outputGuidance.textContent = i18n.t(copy.outputFirstRun.guidance);
+    return;
+  }
+
+  if (status.failure_reason || recentRuns?.summary?.attention_state === "failure_cluster") {
+    outputContext.textContent = i18n.t(copy.outputFailure.context);
+    outputGuidance.textContent = i18n.t(copy.outputFailure.guidance);
+    return;
+  }
+
+  outputContext.textContent = i18n.t(copy.outputSteady.context);
+  outputGuidance.textContent = i18n.t(copy.outputSteady.guidance);
 }
 
 function updateLastUpdated() {
@@ -838,6 +1032,8 @@ function rerenderLocalizedView() {
     setPill(accessPill, "WARN");
   }
 
+  renderOperatorFocus(uiState.status, uiState.recentRuns, uiState.doctor, uiState.access);
+  renderOutputMeta(uiState.status, uiState.recentRuns);
   syncOutputForLocale();
   syncToolPills();
   setBanner(computeBannerMessage(uiState.status, uiState.recentRuns, uiState.access));

--- a/web/i18n.js
+++ b/web/i18n.js
@@ -85,9 +85,16 @@
       ui: {
         title: "Notes Snapshot Console",
         badgeLocal: "LOCAL",
-        heroSummary: "Deterministic local Web console for Apple Notes exports, without requiring a bundled desktop app.",
+        heroSummary: "Run one snapshot, install launchd, then verify the loop before you read deeper diagnostics or builder lanes.",
         refresh: "Refresh",
         lastUpdate: "Last update",
+        operatorLane: "Run -> Install -> Verify",
+        operatorStepOne: "Step 1",
+        operatorStepTwo: "Step 2",
+        operatorStepThree: "Step 3",
+        operatorStepRunTitle: "Run one snapshot",
+        operatorStepInstallTitle: "Install the scheduler",
+        operatorStepVerifyTitle: "Verify before diagnostics",
         firstRunGuidance: "First-Run Guidance",
         snapshotStatus: "Snapshot Status",
         logHealth: "Log Health",
@@ -100,6 +107,12 @@
         vendorSync: "Vendor Sync",
         logViewer: "Log Viewer",
         actionOutput: "Action Output",
+        operatorFocusDeck: "Operator Focus Deck",
+        nextMovePill: "next move",
+        currentNextMove: "Current next move",
+        readOrder: "Read order",
+        controlRoomSignals: "Control-room signals",
+        latestActionTranscript: "Latest action transcript",
         healthSummary: "Health Summary",
         stateLayers: "State Layers",
         healthReasonCodes: "Health Reason Codes",
@@ -193,11 +206,71 @@
         apiUnavailable: "Unable to reach local API. If this persists, ensure Web UI server is running.",
         runningAction: "Running {action}...",
         actionFailed: "Action failed: {detail}",
-        firstRunSummary: "Build one successful snapshot first, then treat the rest of the control room as ongoing operations.",
+        operatorLaneSummary: "Treat the first healthy loop like a three-step lane: build one baseline, install the schedule, then verify before you read deeper telemetry.",
+        operatorStepRun: "Use Run Snapshot first so macOS can show permissions and the local ledger can record a real baseline.",
+        operatorStepInstall: "Use the Scheduler card once the first run succeeds so the loop becomes repeatable instead of manual.",
+        operatorStepVerify: "Verify first, then use Doctor, Recent Runs, and Log Health only when the loop still looks wrong.",
+        operatorLaneHintHtml:
+          'Need the guided version? Open the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/">quickstart</a>, then the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/troubleshooting/">troubleshooting guide</a>, and keep the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/">proof page</a> for after the first verified loop.',
+        operatorFocusDeckSummary:
+          "Read this strip like a control-tower handoff: it tells you what to do next, why that move is safest, and which panel to open before you chase raw logs.",
+        focusReconnectNext: "Reconnect the control room",
+        focusReconnectReason:
+          "The live status feed is not visible yet, so the safest move is to refresh before you trust any deeper panel.",
+        focusReconnectReadOrder: "Refresh -> Snapshot Status -> Recent Runs",
+        focusReconnectGuidance:
+          "Once status is back, read the top health card first and only then drop into diagnostics or raw output.",
+        focusReadonlyNext: "Stay read-only and inspect proof",
+        focusReadonlyReason:
+          "This console is currently locked to observation, so use Status, Recent Runs, and Proof before you expect any action buttons to change local state.",
+        focusReadonlyReadOrder: "Snapshot Status -> Recent Runs -> Proof page",
+        focusReadonlyGuidance:
+          "Treat this like an audit deck: read the health picture first, then the proof trail, and avoid chasing action output as if writes were available.",
+        focusFirstRunNext: "Run one snapshot",
+        focusFirstRunReason:
+          "You do not have a verified baseline yet, so every deeper surface is still describing a first-run setup problem instead of an operating loop.",
+        focusFirstRunReadOrder: "Run Snapshot -> Snapshot Status -> Scheduler",
+        focusFirstRunGuidance:
+          "After the first successful run lands, come back here, confirm the baseline, then install launchd and only after that read the proof or diagnostics surfaces.",
+        focusInstallNext: "Install the scheduler",
+        focusInstallReason:
+          "The manual baseline already exists, but the repeatable loop is not loaded yet, so the next safest move is to turn the snapshot into a visible rhythm.",
+        focusInstallReadOrder: "Scheduler -> Snapshot Status -> Recent Runs",
+        focusInstallGuidance:
+          "Use Install after the successful baseline exists, then refresh Status so the loop reads like a schedule instead of a one-off export.",
+        focusVerifyNext: "Verify the loop, then open Doctor",
+        focusVerifyReason:
+          "The control room is already pointing at drift or failure, so you want to confirm the health contract first and only then open dependency or recovery detail.",
+        focusVerifyReadOrder: "Snapshot Status -> Doctor -> Log Viewer -> Action Output",
+        focusVerifyGuidance:
+          "Think of this like triage: confirm the loop is unhealthy, read the doctor summary, then use logs and raw action output as receipts instead of as your first clue.",
+        focusRecoveryWatchNext: "Read Recent Runs before you take another action",
+        focusRecoveryWatchReason:
+          "The latest pattern shows a repeated or watch-level drift, so you should understand the run trend before you add another manual intervention.",
+        focusRecoveryWatchReadOrder: "Recent Runs -> Snapshot Status -> Log Viewer",
+        focusRecoveryWatchGuidance:
+          "Use Recent Runs to see whether the loop is wobbling in one repeated way, then confirm the current state card before you trigger a fix.",
+        focusSteadyNext: "Confirm steady state, then capture proof",
+        focusSteadyReason:
+          "The baseline, scheduler, and health surface look steady, so the safest operator move is to confirm freshness and then use proof-facing surfaces only as a receipt.",
+        focusSteadyReadOrder: "Snapshot Status -> Recent Runs -> Proof page",
+        focusSteadyGuidance:
+          "When the loop is calm, keep the order short: confirm the latest state, check that the recent run trend is still steady, and only then open proof or builder lanes.",
+        focusSignalHealthLevel: "Health level: {value}",
+        focusSignalLaunchdState: "Launchd state: {value}",
+        focusSignalRecentAttention: "Recent run attention: {value}",
+        focusSignalDoctorWarnings: "Doctor warnings: {count}",
+        focusSignalAccessMode: "Access mode: {value}",
+        focusAccessReadonly: "readonly",
+        focusAccessActive: "active",
+        quickActionsSummary: "Start with Run Snapshot, then return here only if permissions or recovery work still blocks the baseline.",
+        schedulerSummary: "This is the install step. Use it after one successful run so the loop becomes repeatable.",
+        metricsSummary: "Metrics stay here for deeper drift analysis after the baseline already exists. They should not be your first stop on day one.",
+        firstRunSummary: "Build one successful snapshot, install the scheduler, then verify the loop before you treat the rest of the control room as ongoing operations.",
         firstRunHint: "Need the full checklist? Open the quickstart or the troubleshooting guide.",
         firstRunHintHtml:
           'Need the full checklist? Open the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/">quickstart</a> or the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/troubleshooting/">troubleshooting guide</a>.',
-        firstRunExplanation: "This is a normal first-run or cleaned-checkout state. Build one successful snapshot baseline before you read this as an active failure.",
+        firstRunExplanation: "This is a normal first-run or cleaned-checkout state. Build one successful snapshot baseline, install the scheduler, then verify before you read this as an active failure.",
         logHealthLastStatus: "last_status: {status}",
         outputOk: "OK",
         actionFileLabel: "file: {path}",
@@ -208,11 +281,27 @@
         bannerFailureCluster: "Recent runs still point to an active failure cluster: {reason}",
         bannerRecoveryWatch: "The latest run recovered, but keep watching the next run before you call the loop stable.",
         bannerStale: "The snapshot loop looks stale. Refresh it before you treat this as a deeper runtime incident.",
+        focusWaitingSignals: "Waiting for live status.",
+        outputWaitingContext: "Waiting for the first live receipt",
+        outputWaitingGuidance:
+          "Refresh first, then use this transcript to confirm what the console actually changed instead of guessing from stale output.",
+        outputFirstRunContext: "Watch for the first successful baseline",
+        outputFirstRunGuidance:
+          "The next useful transcript should show one clean Run Snapshot receipt. After that, move back to Scheduler and Status before reading deeper logs.",
+        outputFailureContext: "Read the failure receipt before taking another action",
+        outputFailureGuidance:
+          "Use this panel like a signed receipt: look for the failing command and the local state it changed, then go back to Doctor or Recent Runs instead of firing a second fix blindly.",
+        outputSteadyContext: "Latest action transcript",
+        outputSteadyGuidance:
+          "Successful actions should read like a short receipt: command first, then the changed local state.",
+        outputGuidanceSummary:
+          "Successful actions should read like a short receipt: command first, then the changed local state.",
+        outputMetaHint: "Read the summary strip above before you drop into raw output.",
       },
       onboarding: {
         stepRun: "Run ./notesctl run --no-status so macOS can surface the first permission prompts.",
-        stepVerify: "Run ./notesctl verify to confirm the local state ledger now has a successful baseline.",
-        stepDoctor: "Run ./notesctl doctor if the state still looks empty or warnings remain.",
+        stepInstall: "Run ./notesctl install --minutes 30 --load once the first snapshot succeeds so the loop becomes repeatable.",
+        stepVerify: "Run ./notesctl verify to confirm the local state ledger and scheduler now agree on a healthy baseline.",
       },
       backend: {
         status: {
@@ -411,9 +500,16 @@
       ui: {
         title: "Notes Snapshot 控制台",
         badgeLocal: "本地",
-        heroSummary: "用于 Apple Notes 导出的确定性本地 Web 控制台，无需打包桌面应用。",
+        heroSummary: "先运行一次快照，再安装 launchd，然后先校验循环，再去读更深的诊断或 builder 分层。",
         refresh: "刷新",
         lastUpdate: "最后更新",
+        operatorLane: "运行 -> 安装 -> 校验",
+        operatorStepOne: "步骤 1",
+        operatorStepTwo: "步骤 2",
+        operatorStepThree: "步骤 3",
+        operatorStepRunTitle: "先跑一次快照",
+        operatorStepInstallTitle: "安装调度器",
+        operatorStepVerifyTitle: "先校验，再看诊断",
         firstRunGuidance: "首次运行指引",
         snapshotStatus: "快照状态",
         logHealth: "日志健康度",
@@ -426,6 +522,12 @@
         vendorSync: "Vendor 同步",
         logViewer: "日志查看器",
         actionOutput: "操作输出",
+        operatorFocusDeck: "操作员聚焦甲板",
+        nextMovePill: "下一步",
+        currentNextMove: "当前下一步",
+        readOrder: "阅读顺序",
+        controlRoomSignals: "控制室信号",
+        latestActionTranscript: "最近一次操作回执",
         healthSummary: "健康摘要",
         stateLayers: "状态分层",
         healthReasonCodes: "健康原因代码",
@@ -519,11 +621,71 @@
         apiUnavailable: "无法连接本地 API。若一直如此，请确认 Web UI 服务器正在运行。",
         runningAction: "正在执行 {action}...",
         actionFailed: "操作失败：{detail}",
-        firstRunSummary: "先完成一次成功快照，再把控制室里的其他信息当成持续运维状态来看。",
+        operatorLaneSummary: "把第一次健康循环理解成三步主线：先建立一次基线，再安装调度，最后先校验通过，再去读更深层的遥测。",
+        operatorStepRun: "先用“运行快照”让 macOS 弹出权限提示，并让本地状态账本记录到真实基线。",
+        operatorStepInstall: "等第一次运行成功后，再用调度器卡片把循环装起来，让它从手动动作变成可重复节奏。",
+        operatorStepVerify: "先校验，再在循环看起来仍不对时去看诊断、最近运行和日志健康度。",
+        operatorLaneHintHtml:
+          '想看带路版？先打开 <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/">quickstart</a>，再看 <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/troubleshooting/">troubleshooting guide</a>；<a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/">proof page</a> 留到第一次校验通过之后再读。',
+        operatorFocusDeckSummary:
+          "把这一条当作控制塔交接条：它会先告诉你下一步该做什么、为什么这一步最安全，以及在你追原始日志之前该先开哪个面板。",
+        focusReconnectNext: "先恢复控制室连接",
+        focusReconnectReason:
+          "当前还看不到实时状态，所以最安全的动作是先刷新并确认控制室重新连上，再去相信更深层面板。",
+        focusReconnectReadOrder: "刷新 -> 快照状态 -> 最近运行",
+        focusReconnectGuidance:
+          "状态一旦回来，先读顶部健康卡片，再决定是否进入诊断或原始输出。",
+        focusReadonlyNext: "保持只读，先看 proof",
+        focusReadonlyReason:
+          "当前控制室处于只读观察态，所以先用状态、最近运行和 proof 理清现场，不要期待按钮会修改本地状态。",
+        focusReadonlyReadOrder: "快照状态 -> 最近运行 -> Proof page",
+        focusReadonlyGuidance:
+          "把它当审计面板来读：先看健康面，再看 proof 证据，别把 action output 当成还能写入的操作台。",
+        focusFirstRunNext: "先跑一次快照",
+        focusFirstRunReason:
+          "你还没有一个验证过的基线，所以更深的面板现在描述的仍是首次运行问题，而不是已经进入日常运维的循环。",
+        focusFirstRunReadOrder: "运行快照 -> 快照状态 -> 调度器",
+        focusFirstRunGuidance:
+          "第一次成功运行落下后，再回来确认基线、安装 launchd，然后才去看 proof 或诊断分层。",
+        focusInstallNext: "安装调度器",
+        focusInstallReason:
+          "手动基线已经存在，但可重复循环还没有加载，所以最安全的下一步是把快照装成一个看得见节奏的循环。",
+        focusInstallReadOrder: "调度器 -> 快照状态 -> 最近运行",
+        focusInstallGuidance:
+          "先完成安装，再刷新状态，让这个系统读起来像有节奏的循环，而不是一次性导出。",
+        focusVerifyNext: "先校验循环，再打开诊断",
+        focusVerifyReason:
+          "控制室已经在提示漂移或失败，所以你应该先确认健康契约，再去看依赖、恢复线索和原始输出。",
+        focusVerifyReadOrder: "快照状态 -> Doctor -> 日志查看器 -> 操作输出",
+        focusVerifyGuidance:
+          "把它理解成分诊：先确认循环确实不健康，再读 doctor 摘要，最后把日志和原始输出当回执，而不是第一条线索。",
+        focusRecoveryWatchNext: "先读最近运行，再决定要不要继续操作",
+        focusRecoveryWatchReason:
+          "最近的模式说明循环在反复抖动或仍处在观察期，所以应先看趋势，再决定是否手动干预。",
+        focusRecoveryWatchReadOrder: "最近运行 -> 快照状态 -> 日志查看器",
+        focusRecoveryWatchGuidance:
+          "先看最近运行是否在重复同一种问题，再回到状态卡确认当前面貌，然后再触发修复动作。",
+        focusSteadyNext: "确认稳定，再取 proof",
+        focusSteadyReason:
+          "基线、调度和健康面看起来都稳定，所以最安全的 operator 动作是先确认新鲜度，再把 proof 当作回执，而不是当作排障入口。",
+        focusSteadyReadOrder: "快照状态 -> 最近运行 -> Proof page",
+        focusSteadyGuidance:
+          "循环平稳时，阅读顺序尽量短：先确认最新状态，再看趋势仍然稳定，最后才打开 proof 或 builder 分层。",
+        focusSignalHealthLevel: "健康等级：{value}",
+        focusSignalLaunchdState: "Launchd 状态：{value}",
+        focusSignalRecentAttention: "最近运行关注态：{value}",
+        focusSignalDoctorWarnings: "Doctor 警告数：{count}",
+        focusSignalAccessMode: "访问模式：{value}",
+        focusAccessReadonly: "只读",
+        focusAccessActive: "可操作",
+        quickActionsSummary: "先从“运行快照”开始；只有当权限或恢复动作仍挡住基线时，再回到这里做补救。",
+        schedulerSummary: "这里就是安装步骤。先有一次成功运行，再来把循环装成可重复的调度。",
+        metricsSummary: "指标留给更深的漂移分析。没有基线之前，不要把它当成第一站。",
+        firstRunSummary: "先完成一次成功快照，再安装调度器，最后先校验循环，再把控制室里的其他信息当成持续运维状态来看。",
         firstRunHint: "需要完整清单？打开 quickstart 或 troubleshooting 指南。",
         firstRunHintHtml:
           '想看完整清单？打开 <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/">quickstart</a> 或 <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/troubleshooting/">troubleshooting guide</a>。',
-        firstRunExplanation: "这通常是首次运行或刚清理后的正常状态。先建立一次成功快照基线，再判断它是否属于主动故障。",
+        firstRunExplanation: "这通常是首次运行或刚清理后的正常状态。先建立一次成功快照基线，再安装调度器并完成校验，然后再判断它是否属于主动故障。",
         logHealthLastStatus: "last_status：{status}",
         outputOk: "完成",
         actionFileLabel: "文件：{path}",
@@ -534,11 +696,27 @@
         bannerFailureCluster: "最近运行仍指向一个活跃失败簇：{reason}",
         bannerRecoveryWatch: "最新一次运行已经恢复，但还需要再观察下一次运行，才能判断循环是否真的稳定。",
         bannerStale: "当前更像是快照循环变旧了。先刷新快照，再判断是不是更深层的运行事故。",
+        focusWaitingSignals: "等待实时状态。",
+        outputWaitingContext: "等待第一份实时回执",
+        outputWaitingGuidance:
+          "先刷新；状态回来后，再把这个面板当成动作回执，而不是拿旧输出猜现在发生了什么。",
+        outputFirstRunContext: "盯住第一次成功基线",
+        outputFirstRunGuidance:
+          "下一份真正有价值的输出应该是一张“运行快照成功”的回执。之后先回到调度器和状态，再去读更深日志。",
+        outputFailureContext: "先读失败回执，再决定下一步",
+        outputFailureGuidance:
+          "把这里当签收单：先看失败命令和它改了哪些本地状态，再回到 Doctor 或最近运行，而不是盲目点第二个修复按钮。",
+        outputSteadyContext: "最近一次操作回执",
+        outputSteadyGuidance:
+          "成功动作应该读起来像短回执：先是命令，再是本地状态变化。",
+        outputGuidanceSummary:
+          "成功动作应该读起来像一张短回执：先是命令，再是本地状态变化。",
+        outputMetaHint: "先看上面的摘要条，再进入原始输出。",
       },
       onboarding: {
         stepRun: "运行 ./notesctl run --no-status，让 macOS 先弹出首次权限提示。",
-        stepVerify: "运行 ./notesctl verify，确认本地状态账本已经记录到成功基线。",
-        stepDoctor: "如果状态仍然空白或还有警告，再运行 ./notesctl doctor。",
+        stepInstall: "第一次快照成功后，运行 ./notesctl install --minutes 30 --load，把循环装成可重复的调度。",
+        stepVerify: "运行 ./notesctl verify，确认本地状态账本和调度器现在都已经对齐到健康基线。",
       },
       backend: {
         status: {

--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
         <div class="brand">
           <div class="badge" data-i18n="ui.badgeLocal">LOCAL</div>
           <h1 data-i18n="ui.title">Notes Snapshot Console</h1>
-          <p data-i18n="ui.heroSummary">Deterministic local Web console for Apple Notes exports, without requiring a bundled desktop app.</p>
+          <p data-i18n="ui.heroSummary">Run one snapshot, install launchd, then verify the loop before you read deeper diagnostics or builder lanes.</p>
         </div>
         <div class="actions">
           <label class="locale-picker" for="locale-switcher">
@@ -39,6 +39,43 @@
       </header>
       <div class="banner banner--hidden" id="system-banner" role="status" aria-live="polite" aria-atomic="true"></div>
       <div class="sr-only" id="action-announcer" aria-live="polite" aria-atomic="true"></div>
+      <section class="card card--wide" id="operator-lane-card">
+        <div class="card__header">
+          <h2 data-i18n="ui.operatorLane">Run -> Install -> Verify</h2>
+          <span class="pill pill--sub" data-i18n="pill.onboarding">ONBOARDING</span>
+        </div>
+        <p class="card__intro" data-i18n="message.operatorLaneSummary">
+          Treat the first healthy loop like a three-step lane: build one baseline, install the schedule, then verify before you read deeper telemetry.
+        </p>
+        <div class="metrics">
+          <div class="metric metric--step">
+            <span data-i18n="ui.operatorStepOne">Step 1</span>
+            <strong data-i18n="ui.operatorStepRunTitle">Run one snapshot</strong>
+            <p class="metric__body" data-i18n="message.operatorStepRun">
+              Use Run Snapshot first so macOS can show permissions and the local ledger can record a real baseline.
+            </p>
+          </div>
+          <div class="metric metric--step">
+            <span data-i18n="ui.operatorStepTwo">Step 2</span>
+            <strong data-i18n="ui.operatorStepInstallTitle">Install the scheduler</strong>
+            <p class="metric__body" data-i18n="message.operatorStepInstall">
+              Use the Scheduler card once the first run succeeds so the loop becomes repeatable instead of manual.
+            </p>
+          </div>
+          <div class="metric metric--step">
+            <span data-i18n="ui.operatorStepThree">Step 3</span>
+            <strong data-i18n="ui.operatorStepVerifyTitle">Verify before diagnostics</strong>
+            <p class="metric__body" data-i18n="message.operatorStepVerify">
+              Verify first, then use Doctor, Recent Runs, and Log Health only when the loop still looks wrong.
+            </p>
+          </div>
+        </div>
+        <div class="hint" data-i18n-html="message.operatorLaneHintHtml">
+          Need the guided version? Open the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/">quickstart</a>, then the
+          <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/troubleshooting/">troubleshooting guide</a>, and keep the
+          <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/">proof page</a> for after the first verified loop.
+        </div>
+      </section>
       <section class="card card--wide" id="onboarding-card" hidden>
         <div class="card__header">
           <h2 id="onboarding-title" data-i18n="ui.firstRunGuidance">First-Run Guidance</h2>
@@ -49,8 +86,8 @@
         </p>
         <ol class="list" id="onboarding-steps">
           <li data-i18n="onboarding.stepRun">Run ./notesctl run --no-status so macOS can surface the first permission prompts.</li>
-          <li data-i18n="onboarding.stepVerify">Run ./notesctl verify to confirm the local state ledger now has a successful baseline.</li>
-          <li data-i18n="onboarding.stepDoctor">Run ./notesctl doctor if the state still looks empty or warnings remain.</li>
+          <li data-i18n="onboarding.stepInstall">Run ./notesctl install --minutes 30 --load once the first snapshot succeeds so the loop becomes repeatable.</li>
+          <li data-i18n="onboarding.stepVerify">Run ./notesctl verify to confirm the local state ledger and scheduler now agree on a healthy baseline.</li>
         </ol>
         <div class="hint" id="onboarding-hint" data-i18n-html="message.firstRunHintHtml">
           Need the full checklist? Open the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/">quickstart</a> or the
@@ -58,7 +95,88 @@
         </div>
       </section>
 
+      <section class="card card--wide card--focus" id="operator-focus-card">
+        <div class="card__header">
+          <div>
+            <h2 data-i18n="ui.operatorFocusDeck">Operator Focus Deck</h2>
+            <p class="card__intro" data-i18n="message.operatorFocusDeckSummary">
+              Read this strip like a control-tower handoff: it tells you what to do next, why that move is safest, and which panel to open before you chase raw logs.
+            </p>
+          </div>
+          <span class="pill pill--sub" id="operator-focus-pill" data-i18n="ui.nextMovePill">next move</span>
+        </div>
+        <div class="focus-grid">
+          <article class="focus-card focus-card--priority">
+            <span class="focus-card__label" data-i18n="ui.currentNextMove">Current next move</span>
+            <strong class="focus-card__value" id="operator-focus-next-step">--</strong>
+            <p class="focus-card__body" id="operator-focus-reason">--</p>
+          </article>
+          <article class="focus-card">
+            <span class="focus-card__label" data-i18n="ui.readOrder">Read order</span>
+            <strong class="focus-card__value" id="operator-focus-read-order">--</strong>
+            <p class="focus-card__body" id="operator-focus-guidance">--</p>
+          </article>
+          <article class="focus-card">
+            <span class="focus-card__label" data-i18n="ui.controlRoomSignals">Control-room signals</span>
+            <ul class="list focus-list" id="operator-focus-signals">
+              <li data-i18n="message.focusWaitingSignals">Waiting for live status.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
       <section class="grid">
+        <article class="card" id="actions-card">
+          <div class="card__header">
+            <h2 data-i18n="ui.quickActions">Quick Actions</h2>
+            <span class="pill pill--sub" id="actions-pill" data-i18n="pill.ready">ready</span>
+          </div>
+          <p class="card__intro" data-i18n="message.quickActionsSummary">
+            Start with Run Snapshot, then return here only if permissions or recovery work still blocks the baseline.
+          </p>
+          <div class="button-grid">
+            <button class="btn btn--ghost" data-action="run" data-i18n="ui.runSnapshot">Run Snapshot</button>
+            <button class="btn btn--ghost" data-action="verify" data-i18n="ui.verify">Verify</button>
+            <button class="btn btn--ghost" data-action="permissions" data-i18n="ui.permissions">Permissions</button>
+            <button class="btn btn--ghost" data-action="fix" data-i18n="ui.fastFix">Fast Fix</button>
+            <button class="btn btn--ghost" data-action="self-heal" data-i18n="ui.selfHeal">Self Heal</button>
+            <button class="btn btn--ghost" data-action="setup" data-i18n="ui.perfectSetup">Perfect Setup</button>
+          </div>
+        </article>
+
+        <article class="card" id="schedule-card">
+          <div class="card__header">
+            <h2 data-i18n="ui.scheduler">Scheduler</h2>
+            <span class="pill pill--sub" id="schedule-pill" data-i18n="pill.launchd">launchd</span>
+          </div>
+          <p class="card__intro" data-i18n="message.schedulerSummary">
+            This is the install step. Use it after one successful run so the loop becomes repeatable.
+          </p>
+          <div class="form-grid">
+            <label>
+              <span data-i18n="ui.minutes">Minutes</span>
+              <input id="install-minutes" type="number" min="1" max="120" value="30" />
+            </label>
+            <label>
+              <span data-i18n="ui.intervalSec">Interval (sec)</span>
+              <input id="install-interval" type="number" min="60" max="7200" placeholder="optional" data-i18n-placeholder="ui.placeholderOptional" />
+            </label>
+            <label class="toggle">
+              <input id="install-load" type="checkbox" checked />
+              <span data-i18n="ui.loadAfterInstall">Load after install</span>
+            </label>
+            <label class="toggle">
+              <input id="install-web" type="checkbox" checked />
+              <span data-i18n="ui.keepWebAlive">Keep Web UI alive</span>
+            </label>
+          </div>
+          <div class="button-row">
+            <button class="btn btn--ghost" data-action="install" data-i18n="ui.install">Install</button>
+            <button class="btn btn--ghost" data-action="ensure" data-i18n="ui.ensure">Ensure</button>
+            <button class="btn btn--ghost" data-action="unload" data-i18n="ui.unload">Unload</button>
+          </div>
+        </article>
+
         <article class="card card--wide" id="status-card">
           <div class="card__header">
             <h2 data-i18n="ui.snapshotStatus">Snapshot Status</h2>
@@ -132,44 +250,6 @@
           <div class="phases" id="phases-bars"></div>
         </article>
 
-        <article class="card" id="log-health-card">
-          <div class="card__header">
-            <h2 data-i18n="ui.logHealth">Log Health</h2>
-            <span class="pill pill--sub" id="log-health-pill">--</span>
-          </div>
-          <div class="metrics">
-            <div class="metric">
-              <span data-i18n="ui.totalErrors">Total Errors</span>
-              <strong id="log-errors-total">--</strong>
-            </div>
-            <div class="metric">
-              <span data-i18n="ui.stdout">Stdout</span>
-              <strong id="log-errors-stdout">--</strong>
-            </div>
-            <div class="metric">
-              <span data-i18n="ui.stderr">Stderr</span>
-              <strong id="log-errors-stderr">--</strong>
-            </div>
-            <div class="metric">
-              <span data-i18n="ui.launchdErr">Launchd Err</span>
-              <strong id="log-errors-launchd">--</strong>
-            </div>
-            <div class="metric">
-              <span data-i18n="ui.pattern">Pattern</span>
-              <strong id="log-pattern">--</strong>
-            </div>
-            <div class="metric">
-              <span data-i18n="ui.tailLines">Tail Lines</span>
-              <strong id="log-tail-lines">--</strong>
-            </div>
-            <div class="metric">
-              <span data-i18n="ui.tailConfig">Tail Config</span>
-              <input id="log-health-tail" type="number" min="50" max="2000" value="200" data-i18n-aria-label="ui.tailConfig" aria-label="Tail Config" />
-            </div>
-          </div>
-          <div class="hint" id="log-health-hint"></div>
-        </article>
-
         <article class="card" id="doctor-card">
           <div class="card__header">
             <h2 data-i18n="ui.doctor">Doctor</h2>
@@ -202,20 +282,6 @@
               <strong id="doctor-state">--</strong>
             </div>
           </div>
-        </article>
-
-        <article class="card card--wide" id="metrics-card">
-          <div class="card__header">
-            <h2 data-i18n="ui.recentMetrics">Recent Metrics</h2>
-            <span class="pill pill--sub" id="metrics-pill">--</span>
-          </div>
-          <div class="form-grid form-grid--wide">
-            <label>
-              <span data-i18n="ui.runIdFilter">Run ID Filter</span>
-              <input id="metrics-run-id" type="text" placeholder="run_id contains..." data-i18n-placeholder="ui.placeholderRunIdContains" />
-            </label>
-          </div>
-          <div class="table" id="metrics-table"></div>
         </article>
 
         <article class="card" id="recent-runs-card">
@@ -267,6 +333,44 @@
           </div>
         </article>
 
+        <article class="card" id="log-health-card">
+          <div class="card__header">
+            <h2 data-i18n="ui.logHealth">Log Health</h2>
+            <span class="pill pill--sub" id="log-health-pill">--</span>
+          </div>
+          <div class="metrics">
+            <div class="metric">
+              <span data-i18n="ui.totalErrors">Total Errors</span>
+              <strong id="log-errors-total">--</strong>
+            </div>
+            <div class="metric">
+              <span data-i18n="ui.stdout">Stdout</span>
+              <strong id="log-errors-stdout">--</strong>
+            </div>
+            <div class="metric">
+              <span data-i18n="ui.stderr">Stderr</span>
+              <strong id="log-errors-stderr">--</strong>
+            </div>
+            <div class="metric">
+              <span data-i18n="ui.launchdErr">Launchd Err</span>
+              <strong id="log-errors-launchd">--</strong>
+            </div>
+            <div class="metric">
+              <span data-i18n="ui.pattern">Pattern</span>
+              <strong id="log-pattern">--</strong>
+            </div>
+            <div class="metric">
+              <span data-i18n="ui.tailLines">Tail Lines</span>
+              <strong id="log-tail-lines">--</strong>
+            </div>
+            <div class="metric">
+              <span data-i18n="ui.tailConfig">Tail Config</span>
+              <input id="log-health-tail" type="number" min="50" max="2000" value="200" data-i18n-aria-label="ui.tailConfig" aria-label="Tail Config" />
+            </div>
+          </div>
+          <div class="hint" id="log-health-hint"></div>
+        </article>
+
         <article class="card" id="access-card">
           <div class="card__header">
             <h2 data-i18n="ui.accessPolicy">Access Policy</h2>
@@ -311,49 +415,21 @@
           </div>
         </article>
 
-        <article class="card" id="actions-card">
+        <article class="card card--wide" id="metrics-card">
           <div class="card__header">
-            <h2 data-i18n="ui.quickActions">Quick Actions</h2>
-            <span class="pill pill--sub" id="actions-pill" data-i18n="pill.ready">ready</span>
+            <h2 data-i18n="ui.recentMetrics">Recent Metrics</h2>
+            <span class="pill pill--sub" id="metrics-pill">--</span>
           </div>
-          <div class="button-grid">
-            <button class="btn btn--ghost" data-action="setup" data-i18n="ui.perfectSetup">Perfect Setup</button>
-            <button class="btn btn--ghost" data-action="run" data-i18n="ui.runSnapshot">Run Snapshot</button>
-            <button class="btn btn--ghost" data-action="verify" data-i18n="ui.verify">Verify</button>
-            <button class="btn btn--ghost" data-action="fix" data-i18n="ui.fastFix">Fast Fix</button>
-            <button class="btn btn--ghost" data-action="self-heal" data-i18n="ui.selfHeal">Self Heal</button>
-            <button class="btn btn--ghost" data-action="permissions" data-i18n="ui.permissions">Permissions</button>
-          </div>
-        </article>
-
-        <article class="card" id="schedule-card">
-          <div class="card__header">
-            <h2 data-i18n="ui.scheduler">Scheduler</h2>
-            <span class="pill pill--sub" id="schedule-pill" data-i18n="pill.launchd">launchd</span>
-          </div>
-          <div class="form-grid">
+          <p class="card__intro" data-i18n="message.metricsSummary">
+            Metrics stay here for deeper drift analysis after the baseline already exists. They should not be your first stop on day one.
+          </p>
+          <div class="form-grid form-grid--wide">
             <label>
-              <span data-i18n="ui.minutes">Minutes</span>
-              <input id="install-minutes" type="number" min="1" max="120" value="30" />
-            </label>
-            <label>
-              <span data-i18n="ui.intervalSec">Interval (sec)</span>
-              <input id="install-interval" type="number" min="60" max="7200" placeholder="optional" data-i18n-placeholder="ui.placeholderOptional" />
-            </label>
-            <label class="toggle">
-              <input id="install-load" type="checkbox" checked />
-              <span data-i18n="ui.loadAfterInstall">Load after install</span>
-            </label>
-            <label class="toggle">
-              <input id="install-web" type="checkbox" checked />
-              <span data-i18n="ui.keepWebAlive">Keep Web UI alive</span>
+              <span data-i18n="ui.runIdFilter">Run ID Filter</span>
+              <input id="metrics-run-id" type="text" placeholder="run_id contains..." data-i18n-placeholder="ui.placeholderRunIdContains" />
             </label>
           </div>
-          <div class="button-row">
-            <button class="btn btn--ghost" data-action="install" data-i18n="ui.install">Install</button>
-            <button class="btn btn--ghost" data-action="ensure" data-i18n="ui.ensure">Ensure</button>
-            <button class="btn btn--ghost" data-action="unload" data-i18n="ui.unload">Unload</button>
-          </div>
+          <div class="table" id="metrics-table"></div>
         </article>
 
         <article class="card card--wide" id="vendor-card">
@@ -426,6 +502,17 @@
           <div class="card__header">
             <h2 data-i18n="ui.actionOutput">Action Output</h2>
             <span class="pill pill--sub" id="output-pill" data-i18n="pill.idle">idle</span>
+          </div>
+          <div class="console-meta">
+            <div class="console-meta__copy">
+              <strong id="output-context" data-i18n="ui.latestActionTranscript">Latest action transcript</strong>
+              <p id="output-guidance" data-i18n="message.outputGuidanceSummary">
+                Successful actions should read like a short receipt: command first, then the changed local state.
+              </p>
+            </div>
+            <div class="console-meta__hint">
+              <span data-i18n="message.outputMetaHint">Read the summary strip above before you drop into raw output.</span>
+            </div>
           </div>
           <pre class="console" id="action-output" tabindex="0" data-i18n="emptyState.noActionsYet">No actions yet.</pre>
         </article>

--- a/web/styles.css
+++ b/web/styles.css
@@ -247,11 +247,66 @@ select:focus-visible {
   grid-column: span 8;
 }
 
+.card--focus {
+  background:
+    linear-gradient(140deg, rgba(255, 255, 255, 0.92), rgba(236, 254, 255, 0.82)),
+    radial-gradient(circle at top right, rgba(34, 211, 238, 0.12), transparent 55%);
+}
+
 .card__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 18px;
+}
+
+.card__intro {
+  margin-bottom: 16px;
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+
+.focus-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.focus-card {
+  display: grid;
+  gap: 10px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(12, 127, 122, 0.12);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.focus-card--priority {
+  background: linear-gradient(180deg, rgba(12, 127, 122, 0.12), rgba(255, 255, 255, 0.82));
+  border-color: rgba(12, 127, 122, 0.22);
+}
+
+.focus-card__label {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.focus-card__value {
+  font-size: 20px;
+  line-height: 1.35;
+  color: var(--ink-1);
+}
+
+.focus-card__body {
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+
+.focus-list {
+  gap: 10px;
+  margin: 0;
 }
 
 .metrics {
@@ -271,6 +326,19 @@ select:focus-visible {
 .metric strong {
   font-size: 18px;
   color: var(--ink-1);
+}
+
+.metric--step {
+  padding: 14px;
+  border-radius: 16px;
+  background: rgba(12, 127, 122, 0.08);
+  border: 1px solid rgba(12, 127, 122, 0.12);
+}
+
+.metric__body {
+  margin: 0;
+  color: var(--ink-2);
+  line-height: 1.5;
 }
 
 .pill {
@@ -423,6 +491,35 @@ select:focus-visible {
   flex-wrap: wrap;
 }
 
+.console-meta {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 14px;
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: rgba(12, 127, 122, 0.07);
+  border: 1px solid rgba(12, 127, 122, 0.12);
+}
+
+.console-meta__copy {
+  display: grid;
+  gap: 6px;
+}
+
+.console-meta__copy strong {
+  color: var(--ink-1);
+  font-size: 15px;
+}
+
+.console-meta__copy p,
+.console-meta__hint {
+  color: var(--ink-2);
+  line-height: 1.55;
+  font-size: 13px;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -480,13 +577,20 @@ select {
 }
 
 .console {
-  background: #0f151a;
-  color: #d1f7f2;
-  padding: 16px;
-  border-radius: 16px;
-  font-size: 12px;
-  line-height: 1.5;
-  height: 240px;
+  margin: 0;
+  min-height: 220px;
+  max-height: 440px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.96), rgba(15, 23, 42, 0.88)),
+    radial-gradient(circle at top, rgba(34, 211, 238, 0.14), transparent 55%);
+  color: #d7f9f5;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  font-family: "SFMono-Regular", "Menlo", "Monaco", monospace;
+  font-size: 13px;
+  line-height: 1.72;
   overflow: auto;
   white-space: pre-wrap;
 }
@@ -520,6 +624,12 @@ select {
   }
   .form-grid--wide {
     grid-template-columns: 1fr;
+  }
+  .focus-grid {
+    grid-template-columns: 1fr;
+  }
+  .console-meta {
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
## Summary
- reland the scoped second-pass operator control room UI/UX slice under the repo-owner identity that can emit the required PR checks
- preserve the same clean 7-file scope as PR #25
- supersede PR #25 only because its author/review/check identity path is awkward under current GitHub rules

## Scope
- README.md
- docs/index.html
- web/index.html
- web/app.js
- web/i18n.js
- web/styles.css
- tests/unit/test_web_i18n_contract.py

## Verification
- python3 -m pytest -q -o addopts= tests/unit/test_web_i18n_contract.py
- git diff --check -- README.md docs/index.html web/index.html web/app.js web/i18n.js web/styles.css tests/unit/test_web_i18n_contract.py

## Supersedes
- supersedes PR #25 for merge mechanics only; code intent and scope are identical
