### PR TITLE
fix: sync snapshot listing truth and guard first-success path

### DIFF
--- a/docs/for-agents/integration-pack/index.html
+++ b/docs/for-agents/integration-pack/index.html
@@ -260,7 +260,7 @@
         <p>
           Need the repo-owned submit metadata for the standalone public skill packet? Use
           <a href="https://github.com/xiaojiou176-open/apple-notes-snapshot/blob/main/examples/public-skills/notes-snapshot-control-room/manifest.yaml">the public skill manifest</a>.
-          It keeps the ClawHub-style submit fields next to <code>SKILL.md</code> without claiming a live listing already exists.
+          It keeps the live ClawHub listing truth and the still-not-accepted OpenHands lane next to <code>SKILL.md</code> without treating either surface as universal attach proof.
         </p>
         <p>
           Need the plugin-grade bundle files? Use the root marketplace files for
@@ -300,7 +300,7 @@
               <td><strong>OpenClaw starter pack</strong></td>
               <td>OpenClaw MCP registry path and bundle-compatible host prep</td>
               <td>Registry payload, set command, verify path, truthful ClawHub boundary, and a tagged host-proof trail in <a href="../../releases/v0.1.12/">v0.1.12</a></td>
-              <td>No ClawHub listing and no universal attach proof on every machine</td>
+              <td>No universal attach proof on every machine and no repo-owned promise that every OpenClaw build already attaches the same way</td>
             </tr>
             <tr>
               <td><strong>Public skills pack</strong></td>

--- a/docs/for-agents/openclaw-starter-pack/index.html
+++ b/docs/for-agents/openclaw-starter-pack/index.html
@@ -142,7 +142,7 @@
         <ul>
           <li><strong>What exists</strong>: OpenClaw documents ClawHub as a real public registry and discovery route.</li>
           <li><strong>What this repo ships now</strong>: MCP registry payloads plus a bundle-compatible local plugin pack that follows the documented Claude/Codex-style bundle layouts OpenClaw can read, and a tagged OpenClaw attach-proof trail in <a href="../../releases/v0.1.12/">v0.1.12</a>.</li>
-          <li><strong>What still stays outside this round</strong>: a live ClawHub listing or a repo-owned guarantee that every OpenClaw build already attaches the same way.</li>
+          <li><strong>What still stays outside this round</strong>: repo-owned guarantees about platform moderation outcomes, or a repo-owned guarantee that every OpenClaw build already attaches the same way.</li>
         </ul>
       </section>
 

--- a/examples/public-skills/notes-snapshot-control-room/manifest.yaml
+++ b/examples/public-skills/notes-snapshot-control-room/manifest.yaml
@@ -10,20 +10,23 @@ skill:
 
 registry_targets:
   clawhub:
-    status: ready-but-not-listed
+    status: listed-live
     package_shape: skill-folder
     submit_via: clawhub publish <repo-root>/examples/public-skills/notes-snapshot-control-room --slug notes-snapshot-control-room --name "Apple Notes Snapshot Control-Room" --version 1.0.2 --tags apple-notes,local-first,backup,mcp
   openhands-extensions:
-    status: folder-ready
+    status: submission-done-platform-not-accepted-yet
+    review_state: changes-requested
     package_shape: skill-folder
     submit_via: submit this folder as skills/notes-snapshot-control-room/ in OpenHands/extensions
 
 boundaries:
   product_identity: Apple Notes local-first backup control room for macOS
   attach_proof_baseline: Tagged v0.1.12 named-host attach proof is the last repo-owned baseline; other machines still need local verification.
-  official_listing_state: not-yet-listed
+  official_listing_state: mixed-live-and-submission-done
+  listing_truth:
+    - ClawHub listing is live today for notes-snapshot-control-room.
+    - OpenHands/extensions #150 is submitted with changes requested and is not accepted or listed live.
   not_claimed:
-    - No live ClawHub listing exists yet
     - No live OpenHands skill listing exists yet
     - No hosted runtime or Docker lane for the full product
     - No universal attach proof on every machine

--- a/tests/unit/test_public_frontdoor_contract.py
+++ b/tests/unit/test_public_frontdoor_contract.py
@@ -1,0 +1,102 @@
+import unittest
+from pathlib import Path
+
+
+class PublicFrontDoorContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo_root = Path(__file__).resolve().parents[2]
+        cls.readme = (cls.repo_root / "README.md").read_text(encoding="utf-8")
+        cls.docs_index = (cls.repo_root / "docs" / "index.html").read_text(encoding="utf-8")
+        cls.web_index = (cls.repo_root / "web" / "index.html").read_text(encoding="utf-8")
+
+    def assert_order(self, content, earlier, later):
+        earlier_index = content.find(earlier)
+        later_index = content.find(later)
+        self.assertNotEqual(earlier_index, -1, f"missing expected marker: {earlier}")
+        self.assertNotEqual(later_index, -1, f"missing expected marker: {later}")
+        self.assertLess(
+            earlier_index,
+            later_index,
+            f"expected {earlier!r} to appear before {later!r}",
+        )
+
+    def test_readme_keeps_run_install_verify_before_builder_lane(self):
+        self.assertIn("## Start with Run -> Install -> Verify", self.readme)
+        self.assertIn("[Start the 3-step quickstart]", self.readme)
+        self.assertIn("[Open the proof page]", self.readme)
+        self.assertIn("[Get support or routing help]", self.readme)
+        self.assertIn("## Builder and maintainer lanes after the operator path", self.readme)
+        self.assertIn("Secondary builder reads after the first healthy loop:", self.readme)
+        self.assertIn("[For Codex / Claude Code builders]", self.readme)
+
+        self.assert_order(
+            self.readme,
+            "## Start with Run -> Install -> Verify",
+            "## Builder and maintainer lanes after the operator path",
+        )
+        self.assert_order(
+            self.readme,
+            "[Get support or routing help]",
+            "Secondary builder reads after the first healthy loop:",
+        )
+        self.assert_order(
+            self.readme,
+            "Secondary builder reads after the first healthy loop:",
+            "[For Codex / Claude Code builders]",
+        )
+
+    def test_docs_front_door_keeps_first_success_ctas_ahead_of_builder_lane(self):
+        self.assertIn("Operator first. Builder-ready only after the loop feels obvious.", self.docs_index)
+        self.assertIn("Start the 3-step quickstart", self.docs_index)
+        self.assertIn("First-run troubleshooting", self.docs_index)
+        self.assertIn("Open the proof page", self.docs_index)
+        self.assertIn(">Run one snapshot and let macOS show the real permission prompts.<", self.docs_index)
+        self.assertIn(">Install the loop so backups stop depending on your memory.<", self.docs_index)
+        self.assertIn(">Verify the loop, then open proof and diagnostics with context.<", self.docs_index)
+        self.assertIn(">For Agents<", self.docs_index)
+        self.assertIn("Open the builder lane", self.docs_index)
+        self.assertIn("Open the builder shelf last", self.docs_index)
+
+        self.assert_order(
+            self.docs_index,
+            "Start the 3-step quickstart",
+            "Open the builder lane",
+        )
+        self.assert_order(
+            self.docs_index,
+            "Open the proof page",
+            "Open the builder lane",
+        )
+        self.assert_order(
+            self.docs_index,
+            "Step 1",
+            "Step 2",
+        )
+        self.assert_order(
+            self.docs_index,
+            "Step 2",
+            "Step 3",
+        )
+
+    def test_web_console_preserves_the_same_first_success_spine(self):
+        self.assertIn('data-i18n="ui.operatorLane">Run -> Install -> Verify</h2>', self.web_index)
+        self.assertIn(
+            'Run one snapshot, install launchd, then verify the loop before you read deeper diagnostics or builder lanes.',
+            self.web_index,
+        )
+        self.assertIn("Open the <a href=\"https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/\">quickstart</a>", self.web_index)
+        self.assertIn("troubleshooting guide", self.web_index)
+        self.assertIn("proof page</a> for after the first verified loop", self.web_index)
+        self.assertIn("Run ./notesctl run --no-status", self.web_index)
+        self.assertIn("Run ./notesctl install --minutes 30 --load", self.web_index)
+        self.assertIn("Run ./notesctl verify", self.web_index)
+
+        self.assert_order(self.web_index, "quickstart", "troubleshooting guide")
+        self.assert_order(self.web_index, "troubleshooting guide", "proof page")
+        self.assert_order(self.web_index, "Run ./notesctl run --no-status", "Run ./notesctl install --minutes 30 --load")
+        self.assert_order(self.web_index, "Run ./notesctl install --minutes 30 --load", "Run ./notesctl verify")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_registry_lane_unit.py
+++ b/tests/unit/test_registry_lane_unit.py
@@ -43,8 +43,17 @@ class RegistryLaneUnitTests(unittest.TestCase):
         self.assertIn("name: notes-snapshot-control-room", manifest_text)
         self.assertIn('display_name: Apple Notes Snapshot Control-Room', manifest_text)
         self.assertIn("version: 1.0.2", manifest_text)
-        self.assertIn("status: ready-but-not-listed", manifest_text)
-        self.assertIn("No live ClawHub listing exists yet", manifest_text)
+        self.assertIn("status: listed-live", manifest_text)
+        self.assertIn("status: submission-done-platform-not-accepted-yet", manifest_text)
+        self.assertIn("review_state: changes-requested", manifest_text)
+        self.assertIn("official_listing_state: mixed-live-and-submission-done", manifest_text)
+        self.assertIn("ClawHub listing is live today for notes-snapshot-control-room.", manifest_text)
+        self.assertIn(
+            "OpenHands/extensions #150 is submitted with changes requested and is not accepted or listed live.",
+            manifest_text,
+        )
+        self.assertNotIn("status: ready-but-not-listed", manifest_text)
+        self.assertNotIn("No live ClawHub listing exists yet", manifest_text)
         self.assertRegex(
             manifest_text,
             re.compile(


### PR DESCRIPTION
## Summary
- sync the snapshot public-skill listing truth to today's ClawHub/OpenHands reality
- add a narrow public front-door contract smoke for the first-success path
- keep builder-facing docs honest about live listing vs universal attach proof
- replay the validated change as an SSH-signed commit to satisfy required_signatures

## Validation
- `python3 -m pytest -o addopts='' tests/unit/test_registry_lane_unit.py -q`
- `python3 -m pytest -o addopts='' tests/unit/test_public_frontdoor_contract.py -q`
- `git diff --check`
