### PR TITLE
fix: remove zero cli desktop control hooks

### DIFF
--- a/scripts/ops/zero_cli_install.zsh
+++ b/scripts/ops/zero_cli_install.zsh
@@ -38,7 +38,7 @@ APP_PATH="${ZERO_CLI_APP_PATH:-}"
 ADD_LOGIN_ITEM="${ZERO_CLI_ADD_LOGIN_ITEM:-0}"
 
 notify() {
-  /usr/bin/osascript -e "display notification \"$1\" with title \"Apple Notes Snapshot\"" >/dev/null 2>&1 || true
+  printf '[zero_cli_install] %s\n' "$1" >&2
 }
 
 touch "$NOTES_SNAPSHOT_LOG_DIR/zero_cli_install.log" || true
@@ -47,13 +47,7 @@ notify "Installing launchd services..."
 "$REPO_ROOT/notesctl" install --minutes "$NOTES_SNAPSHOT_INTERVAL_MINUTES" --load --web >> "$NOTES_SNAPSHOT_LOG_DIR/zero_cli_install.log" 2>&1
 
 if [[ -n "$APP_PATH" && "$ADD_LOGIN_ITEM" -eq 1 ]]; then
-  /usr/bin/osascript <<EOF_OSA >/dev/null 2>&1
-    tell application "System Events"
-      if not (exists login item "Notes Snapshot Console") then
-        make login item at end with properties {path:"$APP_PATH", hidden:true}
-      end if
-    end tell
-EOF_OSA
+  printf '%s\n' "[zero_cli_install] Skipping login-item automation for host safety. Add \"$APP_PATH\" manually if you still want it at login." >> "$NOTES_SNAPSHOT_LOG_DIR/zero_cli_install.log"
 fi
 
 notify "Opening Web UI..."

--- a/tests/unit/test_zero_cli_install_contract.py
+++ b/tests/unit/test_zero_cli_install_contract.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+
+class ZeroCliInstallContractTests(unittest.TestCase):
+    def test_zero_cli_install_avoids_desktop_control_primitives(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        content = (repo_root / "scripts" / "ops" / "zero_cli_install.zsh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn("/usr/bin/osascript", content)
+        self.assertNotIn('tell application "System Events"', content)
+        self.assertNotIn("display notification", content)
+
+        self.assertIn('"$REPO_ROOT/notesctl" install --minutes "$NOTES_SNAPSHOT_INTERVAL_MINUTES" --load --web', content)
+        self.assertIn("Skipping login-item automation for host safety.", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove osascript/System Events usage from zero_cli_install
- replace desktop control with log-only manual guidance
- add a static contract test to prevent the forbidden primitives from returning

## Validation
- `python3 -m pytest -o addopts='' tests/unit/test_zero_cli_install_contract.py -q`
- `rg -n '/usr/bin/osascript|System Events|display notification' scripts/ops/zero_cli_install.zsh`
- `git diff --check`
