### PR TITLE
docs: sharpen snapshot public listing boundary

### DIFF
--- a/examples/public-skills/notes-snapshot-control-room/README.md
+++ b/examples/public-skills/notes-snapshot-control-room/README.md
@@ -57,7 +57,8 @@ without inventing a hosted-service or plugin-marketplace story.
 ## What this skill does not claim
 
 - no flagship plugin or `.mcpb` lane claim for the full product
-- no live ClawHub or OpenHands skill listing without fresh host-side read-back
+- no live OpenHands skill listing without fresh host-side read-back
+- no universal attach proof just because the secondary ClawHub packet listing is live
 - no hosted runtime or Docker lane for the full product
 - no universal attach proof on every machine
 


### PR DESCRIPTION
## Summary
- tighten the snapshot public-skill README so ClawHub live truth and OpenHands review truth are both explicit
- keep the packet boundary honest without under-claiming the secondary live listing

## Validation
- `python3 -m pytest -o addopts='' tests/unit/test_registry_lane_unit.py -q`
- `git diff --check`
