### PR TITLE
docs: align snapshot front door with distribution ledger

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -1,0 +1,65 @@
+# Distribution Surface
+
+This file is the exact claim boundary for Apple Notes Snapshot's distribution
+story.
+
+Treat it like a shipping ledger, not like the repo's front-door sentence. The
+front door still starts with `Run -> Install -> Verify`, then opens deeper
+builder or listing lanes only after that first healthy local loop exists.
+
+Use this file when you need to answer:
+
+- which repo-owned distribution artifacts are canonical
+- which public listings are live today
+- which lanes are still external-only or review-pending
+- how the MCP descriptor, `.mcpb` package, and public-skill packet converge
+
+## Public Distribution Matrix
+
+| Surface | Repo-owned artifact shipped | Current truthful boundary |
+| --- | --- | --- |
+| Official MCP Registry descriptor | `server.json` | the repo ships the canonical stdio-first MCP descriptor for `io.github.xiaojiou176-open/apple-notes-snapshot`; keep the product story local-first instead of registry-first |
+| Release `.mcpb` companion package | `packaging/mcpb/manifest.json` | the `.mcpb` package is companion packaging around the same `notesctl mcp` workflow, not a separate hosted product |
+| Public standalone skill packet | `examples/public-skills/notes-snapshot-control-room/manifest.yaml` | the public skill packet is repo-owned and listing-ready; ClawHub is live today for this packet lane |
+| OpenHands/extensions skill lane | `examples/public-skills/notes-snapshot-control-room/manifest.yaml` | the packet is submitted, changes requested, and not accepted or listed live yet; treat this as external-only review tail, not a repo blocker |
+
+## Canonical Repo-Owned Artifacts
+
+- `server.json`
+- `packaging/mcpb/manifest.json`
+- `examples/public-skills/notes-snapshot-control-room/manifest.yaml`
+
+These three files describe the same control-room distribution story from three
+angles:
+
+- `server.json` is the MCP descriptor/read-back lane
+- `packaging/mcpb/manifest.json` is the companion `.mcpb` packaging lane
+- `examples/public-skills/notes-snapshot-control-room/manifest.yaml` is the
+  public skill-folder listing lane
+
+## Live And External-Only Boundaries
+
+This section is the current `external-only / review-pending` split.
+
+- **Live today**
+  - official MCP Registry descriptor/read-back for
+    `io.github.xiaojiou176-open/apple-notes-snapshot`
+  - ClawHub is live today for `notes-snapshot-control-room`
+- **External-only / review-pending**
+  - OpenHands/extensions `#150` remains submitted with changes requested and is
+    not accepted or listed live
+
+## Allowed Claims
+
+- "`server.json` is the canonical MCP descriptor for Apple Notes Snapshot"
+- "the release `.mcpb` package is companion packaging around the same local
+  control-room workflow"
+- "the standalone public skill packet ships repo-owned listing metadata"
+- "ClawHub is live today for the public skill packet"
+
+## Forbidden Claims
+
+- "Run -> Install -> Verify is no longer the front door"
+- "the `.mcpb` package proves a hosted runtime"
+- "OpenHands/extensions is live" without fresh accepted read-back
+- "official listing everywhere" or "universal attach proof on every machine"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Secondary builder reads after the first healthy loop:
 [AI Diagnose](https://xiaojiou176-open.github.io/apple-notes-snapshot/ai-diagnose/) |
 [Local Web API](https://xiaojiou176-open.github.io/apple-notes-snapshot/local-api/) |
 [MCP Provider](https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/) |
+[Distribution and listing boundaries](./DISTRIBUTION.md) |
 [For Codex / Claude Code builders](https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/)
 
 ## Quickstart

--- a/docs/for-agents/public-skills/index.html
+++ b/docs/for-agents/public-skills/index.html
@@ -113,6 +113,13 @@
           <li>Use it when you want one portable folder that keeps the control-room identity, preflight-before-attach rule, and starter-pack versus official-listing boundary together.</li>
           <li>It stays public-safe because it does not depend on task boards, machine-private paths, or owner-session-only rituals.</li>
         </ul>
+        <p>
+          When you need the root-level convergence ledger for the MCP descriptor,
+          companion <code>.mcpb</code> package, and public listing state, pair the
+          packet with the repo-owned
+          <a href="https://github.com/xiaojiou176-open/apple-notes-snapshot/blob/main/DISTRIBUTION.md"><code>DISTRIBUTION.md</code></a>
+          surface instead of inferring that boundary from host-specific pages.
+        </p>
       </section>
 
       <section class="page-card">

--- a/docs/index.html
+++ b/docs/index.html
@@ -247,6 +247,11 @@
             <p>Read the tagged public story version by version when you want release truth instead of workshop notes.</p>
             <p><a href="./releases/">Browse release history</a></p>
           </article>
+          <article class="card">
+            <h3>Distribution boundary</h3>
+            <p>Open the repo-owned distribution ledger when you need the exact MCP descriptor, `.mcpb`, and public-skill listing story without turning that lane into the front door.</p>
+            <p><a href="https://github.com/xiaojiou176-open/apple-notes-snapshot/blob/main/DISTRIBUTION.md">Open the distribution ledger</a></p>
+          </article>
           <article class="card card--warm">
             <h3>For Agents</h3>
             <p>Open the builder shelf last, after the control-room contract is clear and you want the truthful Web, AI, or MCP split.</p>

--- a/tests/unit/test_public_frontdoor_contract.py
+++ b/tests/unit/test_public_frontdoor_contract.py
@@ -8,6 +8,9 @@ class PublicFrontDoorContractTests(unittest.TestCase):
         cls.repo_root = Path(__file__).resolve().parents[2]
         cls.readme = (cls.repo_root / "README.md").read_text(encoding="utf-8")
         cls.docs_index = (cls.repo_root / "docs" / "index.html").read_text(encoding="utf-8")
+        cls.public_skills_index = (
+            cls.repo_root / "docs" / "for-agents" / "public-skills" / "index.html"
+        ).read_text(encoding="utf-8")
         cls.web_index = (cls.repo_root / "web" / "index.html").read_text(encoding="utf-8")
 
     def assert_order(self, content, earlier, later):
@@ -28,6 +31,7 @@ class PublicFrontDoorContractTests(unittest.TestCase):
         self.assertIn("[Get support or routing help]", self.readme)
         self.assertIn("## Builder and maintainer lanes after the operator path", self.readme)
         self.assertIn("Secondary builder reads after the first healthy loop:", self.readme)
+        self.assertIn("[Distribution and listing boundaries](./DISTRIBUTION.md)", self.readme)
         self.assertIn("[For Codex / Claude Code builders]", self.readme)
 
         self.assert_order(
@@ -57,6 +61,12 @@ class PublicFrontDoorContractTests(unittest.TestCase):
         self.assertIn(">For Agents<", self.docs_index)
         self.assertIn("Open the builder lane", self.docs_index)
         self.assertIn("Open the builder shelf last", self.docs_index)
+        self.assertIn("Distribution boundary", self.docs_index)
+        self.assertIn("Open the distribution ledger", self.docs_index)
+        self.assertIn(
+            "https://github.com/xiaojiou176-open/apple-notes-snapshot/blob/main/DISTRIBUTION.md",
+            self.docs_index,
+        )
 
         self.assert_order(
             self.docs_index,
@@ -96,6 +106,15 @@ class PublicFrontDoorContractTests(unittest.TestCase):
         self.assert_order(self.web_index, "troubleshooting guide", "proof page")
         self.assert_order(self.web_index, "Run ./notesctl run --no-status", "Run ./notesctl install --minutes 30 --load")
         self.assert_order(self.web_index, "Run ./notesctl install --minutes 30 --load", "Run ./notesctl verify")
+
+    def test_public_skills_page_points_back_to_root_distribution_ledger(self):
+        self.assertIn("DISTRIBUTION.md", self.public_skills_index)
+        self.assertIn("root-level convergence ledger", self.public_skills_index)
+        self.assertIn("companion <code>.mcpb</code> package", self.public_skills_index)
+        self.assertIn(
+            "https://github.com/xiaojiou176-open/apple-notes-snapshot/blob/main/DISTRIBUTION.md",
+            self.public_skills_index,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_registry_lane_unit.py
+++ b/tests/unit/test_registry_lane_unit.py
@@ -67,6 +67,23 @@ class RegistryLaneUnitTests(unittest.TestCase):
         self.assertIn("references/DEMO.md", manifest_text)
         self.assertIn("references/TROUBLESHOOTING.md", manifest_text)
 
+    def test_root_distribution_surface_converges_descriptor_package_and_skill_lanes(self):
+        distribution_text = (self.repo_root / "DISTRIBUTION.md").read_text(encoding="utf-8")
+        self.assertIn("Run -> Install -> Verify", distribution_text)
+        self.assertIn("server.json", distribution_text)
+        self.assertIn("packaging/mcpb/manifest.json", distribution_text)
+        self.assertIn(
+            "examples/public-skills/notes-snapshot-control-room/manifest.yaml",
+            distribution_text,
+        )
+        self.assertIn("ClawHub is live today", distribution_text)
+        self.assertIn(
+            "OpenHands/extensions `#150` remains submitted with changes requested",
+            distribution_text,
+        )
+        self.assertIn("external-only / review-pending", distribution_text)
+        self.assertNotIn("the `.mcpb` package proves a hosted runtime", distribution_text.split("## Allowed Claims", 1)[0])
+
     def test_public_skill_packet_drops_legacy_reference_filenames(self):
         references_dir = (
             self.repo_root


### PR DESCRIPTION
## Summary
- add a root distribution ledger for the MCP descriptor, .mcpb package, and public-skill lane
- link that ledger from the README, docs front door, and public-skills page without replacing the operator-first story
- cover the new convergence surface with front-door and registry-lane unit checks

## Verification
- python3 -m unittest tests.unit.test_public_frontdoor_contract tests.unit.test_registry_lane_unit