### PR TITLE
docs: sync community review receipts

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -21,6 +21,8 @@ Use this file when you need to answer:
 | Official MCP Registry descriptor | `server.json` | the repo ships the canonical stdio-first MCP descriptor for `io.github.xiaojiou176-open/apple-notes-snapshot`; keep the product story local-first instead of registry-first |
 | Release `.mcpb` companion package | `packaging/mcpb/manifest.json` | the `.mcpb` package is companion packaging around the same `notesctl mcp` workflow, not a separate hosted product |
 | Public standalone skill packet | `examples/public-skills/notes-snapshot-control-room/manifest.yaml` | the public skill packet is repo-owned and listing-ready; ClawHub is live today for this packet lane |
+| Goose Skills Marketplace | `examples/public-skills/notes-snapshot-control-room/manifest.yaml` | the public skill packet is submitted on [`block/Agent-Skills#27`](https://github.com/block/Agent-Skills/pull/27); keep this lane at review-pending until maintainers accept it |
+| agent-skill.co source repo | `examples/public-skills/notes-snapshot-control-room/manifest.yaml` | the public packet is submitted to the community index on [`heilcheng/awesome-agent-skills#183`](https://github.com/heilcheng/awesome-agent-skills/pull/183); directory acceptance is still pending |
 | OpenHands/extensions skill lane | `examples/public-skills/notes-snapshot-control-room/manifest.yaml` | the packet is submitted, changes requested, and not accepted or listed live yet; treat this as external-only review tail, not a repo blocker |
 
 ## Canonical Repo-Owned Artifacts
@@ -46,6 +48,10 @@ This section is the current `external-only / review-pending` split.
     `io.github.xiaojiou176-open/apple-notes-snapshot`
   - ClawHub is live today for `notes-snapshot-control-room`
 - **External-only / review-pending**
+  - Goose Skills Marketplace PR `block/Agent-Skills#27` is open and blocked on
+    external maintainer review
+  - community index PR `heilcheng/awesome-agent-skills#183` is open and still
+    waiting on external acceptance
   - OpenHands/extensions `#150` remains submitted with changes requested and is
     not accepted or listed live
 
@@ -56,10 +62,14 @@ This section is the current `external-only / review-pending` split.
   control-room workflow"
 - "the standalone public skill packet ships repo-owned listing metadata"
 - "ClawHub is live today for the public skill packet"
+- "Goose Skills Marketplace submission is review-pending on `block/Agent-Skills#27`"
+- "the community index submission is review-pending on `heilcheng/awesome-agent-skills#183`"
 
 ## Forbidden Claims
 
 - "Run -> Install -> Verify is no longer the front door"
 - "the `.mcpb` package proves a hosted runtime"
+- "Goose Skills Marketplace is listed live" without fresh accepted read-back
+- "agent-skill.co is live" without fresh accepted read-back
 - "OpenHands/extensions is live" without fresh accepted read-back
 - "official listing everywhere" or "universal attach proof on every machine"

--- a/tests/unit/test_registry_lane_unit.py
+++ b/tests/unit/test_registry_lane_unit.py
@@ -78,11 +78,21 @@ class RegistryLaneUnitTests(unittest.TestCase):
         )
         self.assertIn("ClawHub is live today", distribution_text)
         self.assertIn(
+            "Goose Skills Marketplace submission is review-pending on `block/Agent-Skills#27`",
+            distribution_text,
+        )
+        self.assertIn(
+            "the community index submission is review-pending on `heilcheng/awesome-agent-skills#183`",
+            distribution_text,
+        )
+        self.assertIn(
             "OpenHands/extensions `#150` remains submitted with changes requested",
             distribution_text,
         )
         self.assertIn("external-only / review-pending", distribution_text)
         self.assertNotIn("the `.mcpb` package proves a hosted runtime", distribution_text.split("## Allowed Claims", 1)[0])
+        self.assertNotIn("Goose Skills Marketplace is listed live", distribution_text.split("## Allowed Claims", 1)[0])
+        self.assertNotIn("agent-skill.co is live", distribution_text.split("## Allowed Claims", 1)[0])
 
     def test_public_skill_packet_drops_legacy_reference_filenames(self):
         references_dir = (


### PR DESCRIPTION
## Summary
- write the current Goose and community index review receipts into `DISTRIBUTION.md`
- keep both lanes explicitly below listed-live

## Validation
- `python3 -m pytest -o addopts='' tests/unit/test_registry_lane_unit.py`
- fresh read-back of `block/Agent-Skills#27` and `heilcheng/awesome-agent-skills#183`
