### PR TITLE
fix: stabilize launchd runtime surfaces

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -131,7 +131,7 @@
         </div>
       </section>
 
-      <section class="section">
+      <section class="section section--feature-ledger">
         <div class="section__header">
           <span class="section__eyebrow">Why people keep it starred</span>
           <h2>It makes the boring operational part of Apple Notes exports calmer.</h2>
@@ -176,7 +176,7 @@
         </div>
       </section>
 
-      <section class="section two-col">
+      <section class="section section--fit-split two-col">
         <article class="callout">
           <span class="eyebrow-inline">Best fit</span>
           <h3>Use this if you want repeatable local snapshots.</h3>
@@ -205,7 +205,7 @@
         </article>
       </section>
 
-      <section class="section">
+      <section class="section section--showcase-night">
         <div class="section__header">
           <span class="section__eyebrow">See the shape</span>
           <h2>The workflow stays simple, even when the operations surface grows up.</h2>
@@ -226,7 +226,7 @@
         </div>
       </section>
 
-      <section class="section">
+      <section class="section section--next-shelf">
         <div class="section__header">
           <span class="section__eyebrow">After the first verified loop</span>
           <h2>Open the next shelf only after Run, Install, and Verify already make sense.</h2>
@@ -260,7 +260,7 @@
         </div>
       </section>
 
-      <section class="section story">
+      <section class="section section--story story">
         <div class="page-card page-card--warm">
           <span class="section__eyebrow">Founder-style short note</span>
           <h2>Why this project feels different from "just another shell wrapper"</h2>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,27 +1,30 @@
 :root {
-  --bg: #f7f3ea;
-  --bg-2: #dfeeed;
-  --paper: rgba(255, 255, 255, 0.88);
-  --paper-strong: rgba(255, 255, 255, 0.94);
-  --paper-ink: rgba(255, 255, 255, 0.98);
-  --ink: #122027;
-  --ink-2: #20343d;
-  --muted: #5c6870;
+  --bg: #f4f5f7;
+  --bg-2: #fbfbfd;
+  --surface: rgba(255, 255, 255, 0.74);
+  --surface-strong: rgba(255, 255, 255, 0.9);
+  --surface-ink: rgba(255, 255, 255, 0.96);
+  --ink: #1d1d1f;
+  --ink-2: #30343a;
+  --muted: #636974;
   --teal: #0e7c74;
   --teal-deep: #0b5e59;
-  --gold: #e4a11b;
-  --coral: #de6a52;
+  --blue: #0071e3;
+  --blue-soft: rgba(0, 113, 227, 0.12);
+  --gold: #d39a32;
+  --coral: #d96a53;
   --plum: #7b5268;
   --sage: #8ea58f;
-  --line: rgba(18, 32, 39, 0.12);
-  --line-strong: rgba(18, 32, 39, 0.18);
-  --shadow: 0 24px 70px rgba(18, 32, 39, 0.14);
-  --shadow-soft: 0 18px 38px rgba(18, 32, 39, 0.08);
-  --shadow-lift: 0 34px 64px rgba(18, 32, 39, 0.16);
-  --radius: 24px;
-  --max: 1180px;
-  --heading-font: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
-  --body-font: "SF Pro Text", "Inter", "Segoe UI", sans-serif;
+  --line: rgba(29, 29, 31, 0.1);
+  --line-strong: rgba(29, 29, 31, 0.16);
+  --shadow: 0 28px 72px rgba(18, 27, 36, 0.08);
+  --shadow-soft: 0 16px 42px rgba(18, 27, 36, 0.05);
+  --shadow-lift: 0 36px 88px rgba(18, 27, 36, 0.1);
+  --radius: 28px;
+  --max: 1240px;
+  --reading-max: 760px;
+  --heading-font: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Inter", "Helvetica Neue", Arial, sans-serif;
+  --body-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Inter", "Helvetica Neue", Arial, sans-serif;
 }
 
 * {
@@ -37,10 +40,9 @@ body {
   color: var(--ink);
   font-family: var(--body-font);
   background:
-    radial-gradient(circle at top right, rgba(14, 124, 116, 0.18), transparent 32%),
-    radial-gradient(circle at left bottom, rgba(228, 161, 27, 0.18), transparent 28%),
-    radial-gradient(circle at 20% 30%, rgba(123, 82, 104, 0.08), transparent 24%),
-    linear-gradient(135deg, rgba(255, 255, 255, 0.24), transparent 36%),
+    radial-gradient(circle at top left, rgba(14, 124, 116, 0.12), transparent 28%),
+    radial-gradient(circle at top right, rgba(0, 113, 227, 0.08), transparent 22%),
+    radial-gradient(circle at bottom left, rgba(211, 154, 50, 0.08), transparent 24%),
     linear-gradient(180deg, var(--bg-2), var(--bg));
   line-height: 1.6;
   position: relative;
@@ -51,15 +53,15 @@ body::before {
   position: fixed;
   inset: 0;
   background:
-    linear-gradient(rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.18)),
+    linear-gradient(rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.1)),
     repeating-linear-gradient(
       90deg,
       transparent 0,
-      transparent 31px,
-      rgba(18, 32, 39, 0.03) 32px
+      transparent 39px,
+      rgba(29, 29, 31, 0.018) 40px
     );
   pointer-events: none;
-  opacity: 0.35;
+  opacity: 0.18;
 }
 
 .skip-link {
@@ -118,9 +120,9 @@ img {
 }
 
 .site-shell {
-  width: min(100% - 32px, var(--max));
+  width: min(100% - 40px, var(--max));
   margin: 0 auto;
-  padding: 24px 0 88px;
+  padding: 24px 0 96px;
   position: relative;
 }
 
@@ -129,13 +131,13 @@ img {
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  padding: 18px 22px;
+  padding: 14px 18px;
   margin-top: 12px;
-  border-radius: 999px;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.68));
-  border: 1px solid rgba(255, 255, 255, 0.8);
-  backdrop-filter: blur(18px);
-  box-shadow: 0 14px 34px rgba(18, 32, 39, 0.08);
+  border-radius: 26px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.72));
+  border: 1px solid rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(24px) saturate(160%);
+  box-shadow: 0 14px 40px rgba(18, 27, 36, 0.06);
   position: sticky;
   top: 10px;
   z-index: 20;
@@ -152,23 +154,23 @@ img {
 .site-nav__brand {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   max-width: 420px;
 }
 
 .site-nav__eyebrow {
-  font-size: 12px;
-  letter-spacing: 0.14em;
+  font-size: 11px;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--teal);
-  font-weight: 700;
+  font-weight: 650;
 }
 
 .site-nav__title {
-  font-size: 17px;
-  font-weight: 700;
+  font-size: 15px;
+  font-weight: 650;
   font-family: var(--heading-font);
-  letter-spacing: -0.03em;
+  letter-spacing: -0.02em;
 }
 
 .site-nav__links {
@@ -179,18 +181,19 @@ img {
 
 .site-nav__links a {
   text-decoration: none;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--muted);
-  padding: 8px 12px;
+  padding: 9px 12px;
   border-radius: 999px;
-  background: rgba(18, 32, 39, 0.03);
+  background: rgba(255, 255, 255, 0.46);
   border: 1px solid transparent;
+  font-weight: 600;
 }
 
 .site-nav__links a:hover {
   background: rgba(14, 124, 116, 0.08);
   color: var(--teal-deep);
-  border-color: rgba(14, 124, 116, 0.14);
+  border-color: rgba(14, 124, 116, 0.12);
 }
 
 .page-context {
@@ -201,9 +204,9 @@ img {
   margin: 18px 0 0;
   padding: 12px 16px;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.64);
-  border: 1px solid rgba(18, 32, 39, 0.08);
-  box-shadow: 0 12px 28px rgba(18, 32, 39, 0.06);
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid rgba(29, 29, 31, 0.06);
+  box-shadow: 0 12px 28px rgba(18, 27, 36, 0.04);
   color: var(--muted);
   font-size: 13px;
 }
@@ -228,10 +231,10 @@ img {
 
 .hero {
   display: grid;
-  grid-template-columns: 1.08fr 0.92fr;
-  gap: 28px;
-  align-items: center;
-  padding: 64px 0 40px;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 32px;
+  align-items: start;
+  padding: 72px 0 52px;
   position: relative;
 }
 
@@ -240,37 +243,35 @@ img {
 .story,
 .page-hero,
 .page-card {
-  background: var(--paper);
-  border: 1px solid rgba(255, 255, 255, 0.8);
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.76);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  backdrop-filter: blur(20px);
+  backdrop-filter: blur(24px) saturate(160%);
 }
 
 .hero__copy {
-  padding: 38px;
+  padding: 12px 0 8px;
   position: relative;
   overflow: hidden;
-  background:
-    linear-gradient(160deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.76)),
-    radial-gradient(circle at top left, rgba(14, 124, 116, 0.08), transparent 42%);
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  backdrop-filter: none;
 }
 
 .hero__copy::after {
-  content: "";
-  position: absolute;
-  inset: auto -20% -40% 30%;
-  height: 180px;
-  background: radial-gradient(circle, rgba(228, 161, 27, 0.18), transparent 62%);
-  pointer-events: none;
+  display: none;
 }
 
 .hero__copy::before {
   content: "";
   position: absolute;
-  inset: 18px 18px auto;
-  height: 1px;
-  background: linear-gradient(90deg, rgba(14, 124, 116, 0.36), transparent 72%);
+  inset: 0 0 auto;
+  width: 120px;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(14, 124, 116, 0.3), rgba(0, 113, 227, 0.26), transparent 78%);
 }
 
 .hero__eyebrow,
@@ -280,29 +281,32 @@ img {
   gap: 8px;
   padding: 8px 14px;
   border-radius: 999px;
-  background: rgba(14, 124, 116, 0.12);
+  background: rgba(14, 124, 116, 0.08);
   color: var(--teal);
-  font-size: 12px;
-  letter-spacing: 0.14em;
+  font-size: 11px;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  font-weight: 700;
+  font-weight: 650;
 }
 
 .hero h1,
 .page-hero h1 {
   margin: 18px 0 14px;
-  font-size: clamp(34px, 6vw, 60px);
-  line-height: 1.02;
-  letter-spacing: -0.04em;
+  font-size: clamp(40px, 6vw, 72px);
+  line-height: 0.98;
+  letter-spacing: -0.06em;
   font-family: var(--heading-font);
   text-wrap: balance;
+  max-width: 12ch;
 }
 
 .hero p,
 .page-hero p,
 .lede {
-  font-size: 18px;
+  font-size: 17px;
   color: var(--muted);
+  max-width: var(--reading-max);
+  line-height: 1.72;
 }
 
 .hero p + p,
@@ -321,64 +325,92 @@ img {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 12px 18px;
+  min-height: 46px;
+  padding: 12px 20px;
   border-radius: 999px;
   text-decoration: none;
-  font-weight: 700;
+  font-weight: 650;
   border: 1px solid transparent;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
 }
 
 .btn--primary {
-  background: linear-gradient(120deg, var(--teal), #16a394);
+  background: linear-gradient(120deg, var(--teal), #0f8e84);
   color: #fff;
-  box-shadow: 0 16px 28px rgba(14, 124, 116, 0.24);
+  box-shadow: 0 16px 32px rgba(14, 124, 116, 0.18);
 }
 
 .btn--secondary {
-  background: rgba(14, 124, 116, 0.08);
-  color: var(--teal-deep);
-  border-color: rgba(14, 124, 116, 0.18);
+  background: rgba(255, 255, 255, 0.68);
+  color: var(--ink);
+  border-color: rgba(29, 29, 31, 0.08);
+  box-shadow: 0 10px 24px rgba(18, 27, 36, 0.04);
 }
 
 .hero__stats {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 12px;
-  margin-top: 24px;
+  margin-top: 28px;
 }
 
 .hero__stat {
+  flex: 1 1 220px;
   padding: 14px 16px;
-  border-radius: 18px;
-  background: rgba(18, 32, 39, 0.04);
-  border: 1px solid rgba(18, 32, 39, 0.06);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid rgba(29, 29, 31, 0.05);
   position: relative;
   overflow: hidden;
+  box-shadow: 0 10px 22px rgba(18, 27, 36, 0.03);
 }
 
 .hero__stat::before {
   content: "";
   position: absolute;
   inset: 0 auto 0 0;
-  width: 4px;
-  background: linear-gradient(180deg, var(--teal), var(--gold));
+  width: 3px;
+  background: linear-gradient(180deg, var(--teal), var(--blue));
 }
 
 .hero__stat strong {
   display: block;
-  font-size: 24px;
-  margin-bottom: 4px;
+  font-size: 15px;
+  margin-bottom: 6px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
 }
 
 .panel {
-  padding: 20px;
+  padding: 24px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.78)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.82)),
     radial-gradient(circle at top right, rgba(14, 124, 116, 0.08), transparent 42%);
+  position: relative;
 }
 
 .panel img {
   box-shadow: var(--shadow-lift);
+  border-radius: 24px;
+}
+
+.hero > .panel {
+  margin-top: 10px;
+}
+
+.hero > .panel::after {
+  content: "";
+  position: absolute;
+  inset: auto 8% -8% 22%;
+  height: 46px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(17, 20, 24, 0.12), transparent 70%);
+  filter: blur(16px);
+  pointer-events: none;
 }
 
 .hero-curation,
@@ -390,7 +422,7 @@ img {
 
 .hero-curation {
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: 22px;
+  margin-top: 28px;
 }
 
 .signal-strip {
@@ -405,10 +437,10 @@ img {
 .curation-card,
 .signal-card,
 .timeline-card {
-  padding: 22px;
+  padding: 24px;
   border-radius: 24px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(250, 245, 237, 0.86));
-  border: 1px solid rgba(18, 32, 39, 0.08);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.76));
+  border: 1px solid rgba(29, 29, 31, 0.06);
   box-shadow: var(--shadow-soft);
   position: relative;
   overflow: hidden;
@@ -421,14 +453,14 @@ img {
 
 .curation-card:nth-child(2) {
   background:
-    linear-gradient(160deg, rgba(14, 124, 116, 0.08), transparent 58%),
-    var(--paper-ink);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(244, 252, 251, 0.82)),
+    radial-gradient(circle at top right, rgba(14, 124, 116, 0.08), transparent 48%);
 }
 
 .curation-card:nth-child(3) {
   background:
-    linear-gradient(160deg, rgba(123, 82, 104, 0.08), transparent 58%),
-    var(--paper-ink);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(246, 248, 252, 0.84)),
+    radial-gradient(circle at top right, rgba(0, 113, 227, 0.08), transparent 48%);
 }
 
 .curation-card::before,
@@ -436,20 +468,21 @@ img {
 .timeline-card::before {
   content: "";
   display: block;
-  width: 56px;
-  height: 4px;
+  width: 64px;
+  height: 3px;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--teal), var(--gold));
-  margin-bottom: 16px;
+  background: linear-gradient(90deg, var(--teal), var(--blue));
+  margin-bottom: 18px;
 }
 
 .signal-card strong,
 .curation-card strong {
   display: block;
-  margin-bottom: 8px;
-  font-size: 20px;
+  margin-bottom: 10px;
+  font-size: 22px;
   font-family: var(--heading-font);
-  line-height: 1.15;
+  line-height: 1.08;
+  letter-spacing: -0.03em;
 }
 
 .signal-card p,
@@ -459,19 +492,19 @@ img {
 }
 
 .signal-card:nth-child(1) {
-  background: linear-gradient(180deg, rgba(14, 124, 116, 0.08), rgba(255, 255, 255, 0.94));
+  background: linear-gradient(180deg, rgba(14, 124, 116, 0.1), rgba(255, 255, 255, 0.9));
 }
 
 .signal-card:nth-child(2) {
-  background: linear-gradient(180deg, rgba(228, 161, 27, 0.08), rgba(255, 255, 255, 0.94));
+  background: linear-gradient(180deg, rgba(211, 154, 50, 0.1), rgba(255, 255, 255, 0.9));
 }
 
 .signal-card:nth-child(3) {
-  background: linear-gradient(180deg, rgba(123, 82, 104, 0.08), rgba(255, 255, 255, 0.94));
+  background: linear-gradient(180deg, rgba(0, 113, 227, 0.08), rgba(255, 255, 255, 0.9));
 }
 
 .signal-card:nth-child(4) {
-  background: linear-gradient(180deg, rgba(142, 165, 143, 0.08), rgba(255, 255, 255, 0.94));
+  background: linear-gradient(180deg, rgba(142, 165, 143, 0.1), rgba(255, 255, 255, 0.9));
 }
 
 .timeline-grid {
@@ -492,9 +525,9 @@ img {
 }
 
 .timeline-card--featured {
-  background: linear-gradient(160deg, rgba(14, 124, 116, 0.14), rgba(255, 255, 255, 0.96));
-  border-color: rgba(14, 124, 116, 0.18);
-  box-shadow: 0 24px 48px rgba(14, 124, 116, 0.14);
+  background: linear-gradient(160deg, rgba(14, 124, 116, 0.12), rgba(255, 255, 255, 0.94));
+  border-color: rgba(14, 124, 116, 0.14);
+  box-shadow: 0 24px 54px rgba(14, 124, 116, 0.1);
 }
 
 .signal-card {
@@ -509,55 +542,148 @@ img {
 .card--accent,
 .page-card--accent {
   background:
-    linear-gradient(160deg, rgba(14, 124, 116, 0.06), transparent 52%),
-    var(--paper-strong);
-  border-color: rgba(14, 124, 116, 0.16);
-  box-shadow: 0 20px 42px rgba(14, 124, 116, 0.12);
+    linear-gradient(160deg, rgba(14, 124, 116, 0.08), transparent 52%),
+    var(--surface-strong);
+  border-color: rgba(14, 124, 116, 0.12);
+  box-shadow: 0 20px 48px rgba(14, 124, 116, 0.08);
 }
 
 .card--warm,
 .page-card--warm {
   background:
-    linear-gradient(160deg, rgba(228, 161, 27, 0.08), transparent 58%),
-    var(--paper-strong);
-  border-color: rgba(228, 161, 27, 0.18);
-  box-shadow: 0 20px 42px rgba(228, 161, 27, 0.12);
+    linear-gradient(160deg, rgba(211, 154, 50, 0.08), transparent 58%),
+    var(--surface-strong);
+  border-color: rgba(211, 154, 50, 0.14);
+  box-shadow: 0 20px 48px rgba(211, 154, 50, 0.08);
 }
 
 .section {
-  margin-top: 40px;
+  margin-top: 56px;
   position: relative;
+}
+
+.section--feature-ledger {
+  padding: 18px 0 8px;
+}
+
+.section--fit-split {
+  padding: 8px 0 4px;
+}
+
+.section--showcase-night {
+  margin-top: 72px;
+  padding: 36px;
+  border-radius: 34px;
+  background:
+    radial-gradient(circle at top right, rgba(0, 113, 227, 0.18), transparent 28%),
+    radial-gradient(circle at bottom left, rgba(14, 124, 116, 0.18), transparent 26%),
+    linear-gradient(180deg, #13171d, #0f1318);
+  box-shadow: 0 32px 80px rgba(12, 16, 24, 0.16);
+}
+
+.section--showcase-night .section__eyebrow,
+.section--showcase-night .section__header,
+.section--showcase-night h2,
+.section--showcase-night .lede {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.section--showcase-night .section__header::after {
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.84), rgba(0, 113, 227, 0.4));
+}
+
+.section--showcase-night .panel {
+  background:
+    linear-gradient(180deg, rgba(22, 29, 38, 0.92), rgba(17, 23, 31, 0.84)),
+    radial-gradient(circle at top right, rgba(14, 124, 116, 0.12), transparent 46%);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.24);
+}
+
+.section--showcase-night .panel img {
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 56px rgba(0, 0, 0, 0.28);
+}
+
+.section--next-shelf {
+  margin-top: 72px;
+}
+
+.section--next-shelf .cards--routes {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.section--next-shelf .card {
+  min-height: 220px;
+}
+
+.section--next-shelf .cards--routes > .card:nth-child(1),
+.section--next-shelf .cards--routes > .card:nth-child(2) {
+  grid-column: span 2;
+  min-height: 240px;
+}
+
+.section--next-shelf .cards--routes > .card:nth-child(3),
+.section--next-shelf .cards--routes > .card:nth-child(4),
+.section--next-shelf .cards--routes > .card:nth-child(5) {
+  grid-column: span 1;
+}
+
+.section--next-shelf .cards--routes > .card:nth-child(1) {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(244, 252, 251, 0.82)),
+    radial-gradient(circle at top right, rgba(14, 124, 116, 0.1), transparent 46%);
+}
+
+.section--next-shelf .cards--routes > .card:nth-child(2) {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(247, 249, 253, 0.84)),
+    radial-gradient(circle at top right, rgba(0, 113, 227, 0.08), transparent 46%);
+}
+
+.section--next-shelf .cards--routes > .card:nth-child(5) {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(250, 248, 244, 0.8));
+  border-color: rgba(29, 29, 31, 0.05);
+  box-shadow: 0 14px 34px rgba(18, 27, 36, 0.04);
+}
+
+.section--story .page-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(249, 246, 241, 0.86)),
+    radial-gradient(circle at top right, rgba(211, 154, 50, 0.08), transparent 44%);
 }
 
 .section__header {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  margin-bottom: 18px;
-  max-width: 760px;
+  gap: 12px;
+  margin-bottom: 22px;
+  max-width: var(--reading-max);
 }
 
 .section__eyebrow {
   color: var(--teal);
-  letter-spacing: 0.12em;
-  font-size: 12px;
-  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-size: 11px;
+  font-weight: 650;
   text-transform: uppercase;
 }
 
 .section h2 {
   margin: 0;
-  font-size: clamp(28px, 4vw, 40px);
-  letter-spacing: -0.03em;
+  font-size: clamp(32px, 4vw, 48px);
+  letter-spacing: -0.05em;
   font-family: var(--heading-font);
+  line-height: 1.02;
 }
 
 .section__header::after {
   content: "";
-  width: 86px;
-  height: 4px;
+  width: 96px;
+  height: 3px;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--teal), var(--gold));
+  background: linear-gradient(90deg, var(--teal), var(--blue));
 }
 
 .cards,
@@ -580,11 +706,29 @@ img {
 .faq-item,
 .proof-card,
 .callout {
-  padding: 24px;
-  border-radius: 24px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.72));
-  border: 1px solid rgba(18, 32, 39, 0.08);
-  box-shadow: 0 16px 36px rgba(18, 32, 39, 0.08);
+  padding: 28px;
+  border-radius: 26px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.7));
+  border: 1px solid rgba(29, 29, 31, 0.06);
+  box-shadow: 0 16px 44px rgba(18, 27, 36, 0.05);
+}
+
+.section--feature-ledger .card {
+  min-height: 240px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(251, 251, 253, 0.76));
+}
+
+.section--feature-ledger .cards {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.section--feature-ledger .card p {
+  line-height: 1.7;
+}
+
+.section--fit-split .callout {
+  min-height: 100%;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(249, 250, 252, 0.76));
 }
 
 .card,
@@ -601,10 +745,10 @@ img {
   content: "";
   position: absolute;
   inset: 0 0 auto 0;
-  height: 4px;
+  height: 2px;
   border-radius: 24px 24px 0 0;
-  background: linear-gradient(90deg, var(--teal), var(--gold), var(--plum));
-  opacity: 0.9;
+  background: linear-gradient(90deg, rgba(14, 124, 116, 0.34), rgba(0, 113, 227, 0.22), transparent 72%);
+  opacity: 1;
 }
 
 .card:hover,
@@ -613,9 +757,9 @@ img {
 .curation-card:hover,
 .signal-card:hover,
 .timeline-card:hover {
-  transform: translateY(-2px);
+  transform: translateY(-3px);
   transition: transform 0.18s ease, box-shadow 0.18s ease;
-  box-shadow: 0 24px 46px rgba(18, 32, 39, 0.12);
+  box-shadow: 0 24px 56px rgba(18, 27, 36, 0.08);
 }
 
 .card::before,
@@ -626,24 +770,25 @@ img {
   position: absolute;
   inset: 0 0 auto;
   height: 1px;
-  background: linear-gradient(90deg, rgba(14, 124, 116, 0.24), transparent 60%);
+  background: linear-gradient(90deg, rgba(14, 124, 116, 0.22), transparent 60%);
 }
 
 .card h3,
 .faq-item h3,
 .proof-card h3 {
   margin: 0 0 10px;
-  font-size: 20px;
+  font-size: 22px;
   font-family: var(--heading-font);
-  letter-spacing: -0.02em;
+  letter-spacing: -0.03em;
+  line-height: 1.08;
 }
 
 .eyebrow-inline {
   color: var(--coral);
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-weight: 650;
 }
 
 .two-col {
@@ -655,22 +800,22 @@ img {
 }
 
 .callout {
-  border-left: 6px solid var(--gold);
+  border-left: 0;
 }
 
 .page-hero {
-  padding: 34px;
-  margin-top: 34px;
+  padding: 40px;
+  margin-top: 36px;
   background:
-    linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.8)),
-    radial-gradient(circle at top right, rgba(228, 161, 27, 0.1), transparent 50%);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.82)),
+    radial-gradient(circle at top right, rgba(0, 113, 227, 0.08), transparent 46%);
 }
 
 .page-card {
-  padding: 28px;
-  margin-top: 18px;
+  padding: 32px;
+  margin-top: 20px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.82)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.8)),
     linear-gradient(160deg, rgba(14, 124, 116, 0.03), transparent 52%);
 }
 
@@ -687,11 +832,11 @@ img {
 }
 
 .section-note {
-  margin-top: 18px;
+  margin-top: 20px;
   padding: 18px 22px;
   border-radius: 22px;
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px dashed rgba(18, 32, 39, 0.14);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px dashed rgba(29, 29, 31, 0.12);
   color: var(--muted);
   box-shadow: var(--shadow-soft);
 }
@@ -706,8 +851,8 @@ img {
   position: relative;
   padding: 22px 22px 22px 80px;
   border-radius: 24px;
-  background: rgba(255, 255, 255, 0.84);
-  border: 1px solid rgba(18, 32, 39, 0.08);
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(29, 29, 31, 0.06);
   box-shadow: var(--shadow-soft);
 }
 
@@ -736,51 +881,53 @@ pre {
   margin: 16px 0 0;
   padding: 18px;
   border-radius: 18px;
-  background: #102028;
+  background: #10161e;
   color: #edf8f7;
   overflow-x: auto;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
-  margin-top: 14px;
-  border-radius: 20px;
+  margin-top: 18px;
+  border-radius: 24px;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.58);
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: 0 12px 36px rgba(18, 27, 36, 0.04);
 }
 
 tbody tr:nth-child(odd) {
-  background: rgba(18, 32, 39, 0.025);
+  background: rgba(29, 29, 31, 0.018);
 }
 
 tbody tr:hover {
-  background: rgba(14, 124, 116, 0.06);
+  background: rgba(14, 124, 116, 0.05);
 }
 
 th,
 td {
-  padding: 14px 12px;
+  padding: 16px 14px;
   text-align: left;
-  border-bottom: 1px solid rgba(18, 32, 39, 0.1);
+  border-bottom: 1px solid rgba(29, 29, 31, 0.08);
   vertical-align: top;
 }
 
 th {
-  font-size: 13px;
+  font-size: 12px;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   color: var(--muted);
-  background: rgba(18, 32, 39, 0.04);
+  background: rgba(29, 29, 31, 0.025);
 }
 
 .footer {
-  margin-top: 44px;
-  padding: 28px 0 0;
-  border-top: 1px solid rgba(18, 32, 39, 0.12);
+  margin-top: 64px;
+  padding: 32px 0 0;
+  border-top: 1px solid rgba(29, 29, 31, 0.08);
   color: var(--muted);
   font-size: 14px;
-  max-width: 760px;
+  max-width: var(--reading-max);
 }
 
 @media (max-width: 980px) {
@@ -794,6 +941,18 @@ th {
     grid-template-columns: 1fr;
   }
 
+  .section--next-shelf .cards--routes {
+    grid-template-columns: 1fr;
+  }
+
+  .section--feature-ledger .cards {
+    grid-template-columns: 1fr;
+  }
+
+  .section--showcase-night {
+    padding: 24px;
+  }
+
   .site-nav {
     border-radius: 28px;
     flex-direction: column;
@@ -802,7 +961,7 @@ th {
   }
 
   .hero__stats {
-    grid-template-columns: 1fr;
+    flex-direction: column;
   }
 }
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -q --cov=scripts/ops --cov-report=term-missing --cov-fail-under=90
+addopts = -q
 cache_dir = .runtime-cache/pytest
 testpaths = tests

--- a/scripts/checks/run_unit_tests.sh
+++ b/scripts/checks/run_unit_tests.sh
@@ -21,4 +21,9 @@ mkdir -p "${REPO_ROOT}/.runtime-cache/coverage"
 # previous run from a different interpreter/schema does not taint the current gate.
 rm -f "${COVERAGE_FILE}" "${COVERAGE_FILE}".*
 
-"${PYTHON_BIN}" -m pytest tests/unit "$@"
+"${PYTHON_BIN}" -m pytest \
+  --cov=scripts/ops \
+  --cov-report=term-missing \
+  --cov-fail-under=90 \
+  tests/unit \
+  "$@"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.xiaojiou176-open/apple-notes-snapshot",
   "title": "Apple Notes Snapshot",
-  "description": "Stdio-first local MCP surface for the Apple Notes Snapshot backup control room on macOS; the release .mcpb stays companion packaging around the same workflow.",
+  "description": "Stdio-first local MCP for Apple Notes Snapshot backup, export, and restore-precheck workflows.",
   "websiteUrl": "https://xiaojiou176-open.github.io/apple-notes-snapshot/",
   "repository": {
     "url": "https://github.com/xiaojiou176-open/apple-notes-snapshot",

--- a/tests/e2e/test_e2e_launchd_schedule.py
+++ b/tests/e2e/test_e2e_launchd_schedule.py
@@ -150,6 +150,7 @@ exit 0
                         return latest
                     time.sleep(interval_sec)
                 self.fail(message)
+                raise AssertionError(message)
 
             run_log = root_dir / "run_log.txt"
             state_json = state_dir / "state.json"

--- a/tests/e2e/test_e2e_launchd_schedule.py
+++ b/tests/e2e/test_e2e_launchd_schedule.py
@@ -129,6 +129,10 @@ exit 0
                     check=False,
                 )
 
+            def status_payload():
+                result = run_cmd(["status", "--json"], check=True)
+                return json.loads(result.stdout)
+
             def run_log_lines(path: Path) -> int:
                 if not path.exists():
                     return 0
@@ -137,40 +141,68 @@ exit 0
                     return 0
                 return len(content)
 
+            def wait_for(condition, timeout_sec: int, interval_sec: float, message: str):
+                deadline = time.monotonic() + timeout_sec
+                latest = None
+                while time.monotonic() < deadline:
+                    latest = condition()
+                    if latest:
+                        return latest
+                    time.sleep(interval_sec)
+                self.fail(message)
+
             run_log = root_dir / "run_log.txt"
             state_json = state_dir / "state.json"
 
             try:
                 run_cmd(["install", "--minutes", "1", "--load", "--no-web"], check=True)
 
-                # Wait for initial kickstart run
-                deadline = time.time() + 20
-                first_count = 0
-                while time.time() < deadline:
-                    first_count = run_log_lines(run_log)
-                    if first_count >= 1 and state_json.exists():
-                        break
-                    time.sleep(1)
+                # Wait for initial kickstart run to fully settle. The exporter writes
+                # its marker before the wrapper flips state.json from running to success.
+                baseline_payload = wait_for(
+                    lambda: (
+                        payload
+                        if (
+                            run_log_lines(run_log) >= 1
+                            and state_json.exists()
+                            and (payload := status_payload()).get("status") == "success"
+                            and payload.get("last_success_iso")
+                            not in (None, "", "unknown")
+                        )
+                        else None
+                    ),
+                    timeout_sec=20,
+                    interval_sec=1,
+                    message="initial launchd run did not settle to success",
+                )
+                first_count = run_log_lines(run_log)
                 self.assertGreaterEqual(first_count, 1, "initial launchd run did not complete")
+                baseline_last_success = baseline_payload["last_success_iso"]
 
-                # Wait for scheduled second run (StartInterval)
-                max_wait_sec = 90
-                deadline = time.time() + max_wait_sec
-                second_run = False
-                while time.time() < deadline:
-                    if run_log_lines(run_log) >= first_count + 1:
-                        second_run = True
-                        break
-                    time.sleep(2)
-                self.assertTrue(second_run, f"launchd did not trigger within {max_wait_sec}s")
-
-                # Verify status json after scheduled run
-                result = run_cmd(["status", "--json"], check=True)
-                payload = json.loads(result.stdout)
+                # Wait for the scheduled second run to finish, not merely start.
+                payload = wait_for(
+                    lambda: (
+                        current
+                        if (
+                            run_log_lines(run_log) >= first_count + 1
+                            and (current := status_payload()).get("status") == "success"
+                            and current.get("last_success_iso")
+                            not in (None, "", "unknown", baseline_last_success)
+                        )
+                        else None
+                    ),
+                    timeout_sec=90,
+                    interval_sec=2,
+                    message="launchd did not complete a second successful run within 90s",
+                )
                 self.assertEqual(payload.get("status"), "success")
+                self.assertNotEqual(payload.get("last_success_iso"), baseline_last_success)
+                self.assertEqual(payload.get("trigger_source"), "launchd")
                 if state_json.exists():
                     data = json.loads(state_json.read_text(encoding="utf-8"))
                     self.assertEqual(data.get("trigger_source"), "launchd")
+                    self.assertEqual(data.get("status"), "success")
+                    self.assertNotEqual(data.get("last_success_iso"), baseline_last_success)
 
                 info = launchctl_print()
                 self.assertEqual(info.returncode, 0, info.stderr)

--- a/tests/e2e/test_e2e_launchd_watchpaths.py
+++ b/tests/e2e/test_e2e_launchd_watchpaths.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import subprocess
@@ -126,6 +127,10 @@ exit 0
                     check=check,
                 )
 
+            def status_payload():
+                result = run_cmd(["status", "--json"], check=True)
+                return json.loads(result.stdout)
+
             def run_log_lines(path: Path) -> int:
                 if not path.exists():
                     return 0
@@ -135,30 +140,51 @@ exit 0
                 return len(content)
 
             run_log = root_dir / "run_log.txt"
+            state_json = state_dir / "state.json"
 
             try:
                 run_cmd(["install", "--minutes", "60", "--load", "--no-web"], check=True)
 
                 deadline = time.time() + 20
                 first_count = 0
+                baseline_payload = None
                 while time.time() < deadline:
                     first_count = run_log_lines(run_log)
-                    if first_count >= 1:
+                    payload = status_payload() if state_json.exists() else None
+                    if (
+                        first_count >= 1
+                        and payload
+                        and payload.get("status") == "success"
+                        and payload.get("last_success_iso") not in (None, "", "unknown")
+                    ):
+                        baseline_payload = payload
                         break
                     time.sleep(1)
                 self.assertGreaterEqual(first_count, 1, "initial launchd run did not complete")
+                self.assertIsNotNone(baseline_payload, "initial launchd run did not settle to success")
+                baseline_last_success = baseline_payload["last_success_iso"]
 
                 trigger_file = watch_dir / "trigger.txt"
                 trigger_file.write_text(str(time.time()), encoding="utf-8")
 
                 deadline = time.time() + 40
-                second_run = False
+                second_payload = None
                 while time.time() < deadline:
-                    if run_log_lines(run_log) >= first_count + 1:
-                        second_run = True
+                    current = status_payload() if state_json.exists() else None
+                    if (
+                        run_log_lines(run_log) >= first_count + 1
+                        and current
+                        and current.get("status") == "success"
+                        and current.get("last_success_iso")
+                        not in (None, "", "unknown", baseline_last_success)
+                    ):
+                        second_payload = current
                         break
                     time.sleep(2)
-                self.assertTrue(second_run, "WatchPaths did not trigger a run")
+                self.assertIsNotNone(second_payload, "WatchPaths did not trigger a completed successful run")
+                self.assertEqual(second_payload.get("status"), "success")
+                self.assertNotEqual(second_payload.get("last_success_iso"), baseline_last_success)
+                self.assertEqual(second_payload.get("trigger_source"), "launchd")
             finally:
                 run_cmd(["install", "--unload", "--no-web"], check=False)
                 subprocess.run(["launchctl", "bootout", domain, str(plist_path)], capture_output=True)

--- a/web/i18n.js
+++ b/web/i18n.js
@@ -108,6 +108,9 @@
         logViewer: "Log Viewer",
         actionOutput: "Action Output",
         operatorFocusDeck: "Operator Focus Deck",
+        sectionOperateEyebrow: "Operate first",
+        sectionDiagnoseEyebrow: "Diagnose with context",
+        sectionReceiptsEyebrow: "Read the receipts last",
         nextMovePill: "next move",
         currentNextMove: "Current next move",
         readOrder: "Read order",
@@ -214,6 +217,12 @@
           'Need the guided version? Open the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/">quickstart</a>, then the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/troubleshooting/">troubleshooting guide</a>, and keep the <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/">proof page</a> for after the first verified loop.',
         operatorFocusDeckSummary:
           "Read this strip like a control-tower handoff: it tells you what to do next, why that move is safest, and which panel to open before you chase raw logs.",
+        sectionOperate:
+          "These panels should feel like the active flight deck: establish or repair the loop here before you study deeper telemetry.",
+        sectionDiagnose:
+          "Read these cards after the loop exists or after a failure is confirmed. They explain patterns, health drift, and policy boundaries.",
+        sectionReceipts:
+          "Logs and action transcripts are the raw evidence layer. Use them to confirm a theory, not to discover the first one.",
         focusReconnectNext: "Reconnect the control room",
         focusReconnectReason:
           "The live status feed is not visible yet, so the safest move is to refresh before you trust any deeper panel.",
@@ -523,6 +532,9 @@
         logViewer: "日志查看器",
         actionOutput: "操作输出",
         operatorFocusDeck: "操作员聚焦甲板",
+        sectionOperateEyebrow: "先操作",
+        sectionDiagnoseEyebrow: "带着上下文再诊断",
+        sectionReceiptsEyebrow: "最后再读回执",
         nextMovePill: "下一步",
         currentNextMove: "当前下一步",
         readOrder: "阅读顺序",
@@ -629,6 +641,12 @@
           '想看带路版？先打开 <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/">quickstart</a>，再看 <a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/troubleshooting/">troubleshooting guide</a>；<a href="https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/">proof page</a> 留到第一次校验通过之后再读。',
         operatorFocusDeckSummary:
           "把这一条当作控制塔交接条：它会先告诉你下一步该做什么、为什么这一步最安全，以及在你追原始日志之前该先开哪个面板。",
+        sectionOperate:
+          "这些面板属于主动操作层。先在这里建立或修复循环，再去研究更深的遥测信息。",
+        sectionDiagnose:
+          "只有在循环已经存在，或者你已经确认失败之后，再来读这些卡片。它们负责解释模式、健康漂移和策略边界。",
+        sectionReceipts:
+          "日志和操作输出属于原始证据层。用它们来确认一个判断，而不是拿它们当第一条线索。",
         focusReconnectNext: "先恢复控制室连接",
         focusReconnectReason:
           "当前还看不到实时状态，所以最安全的动作是先刷新并确认控制室重新连上，再去相信更深层面板。",

--- a/web/index.html
+++ b/web/index.html
@@ -126,6 +126,12 @@
       </section>
 
       <section class="grid">
+        <div class="grid-label">
+          <span class="grid-label__eyebrow" data-i18n="ui.sectionOperateEyebrow">Operate first</span>
+          <p class="grid-label__body" data-i18n="message.sectionOperate">
+            These panels should feel like the active flight deck: establish or repair the loop here before you study deeper telemetry.
+          </p>
+        </div>
         <article class="card" id="actions-card">
           <div class="card__header">
             <h2 data-i18n="ui.quickActions">Quick Actions</h2>
@@ -284,6 +290,12 @@
           </div>
         </article>
 
+        <div class="grid-label">
+          <span class="grid-label__eyebrow" data-i18n="ui.sectionDiagnoseEyebrow">Diagnose with context</span>
+          <p class="grid-label__body" data-i18n="message.sectionDiagnose">
+            Read these cards after the loop exists or after a failure is confirmed. They explain patterns, health drift, and policy boundaries.
+          </p>
+        </div>
         <article class="card" id="recent-runs-card">
           <div class="card__header">
             <h2 data-i18n="ui.recentRuns">Recent Runs</h2>
@@ -456,6 +468,12 @@
           </div>
         </article>
 
+        <div class="grid-label">
+          <span class="grid-label__eyebrow" data-i18n="ui.sectionReceiptsEyebrow">Read the receipts last</span>
+          <p class="grid-label__body" data-i18n="message.sectionReceipts">
+            Logs and action transcripts are the raw evidence layer. Use them to confirm a theory, not to discover the first one.
+          </p>
+        </div>
         <article class="card card--wide" id="logs-card">
           <div class="card__header">
             <h2 data-i18n="ui.logViewer">Log Viewer</h2>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,16 +1,21 @@
 :root {
-  --bg-1: #f7f2e9;
-  --bg-2: #e7f3f5;
-  --ink-1: #10161b;
-  --ink-2: #384045;
-  --muted: #6b7377;
+  --bg-1: #f3f5f7;
+  --bg-2: #ecf6f6;
+  --ink-1: #111418;
+  --ink-2: #46515a;
+  --muted: #6d7680;
   --accent: #0c7f7a;
-  --accent-2: #f0b429;
-  --accent-3: #e76f51;
-  --card: rgba(255, 255, 255, 0.86);
-  --border: rgba(12, 127, 122, 0.12);
-  --shadow: 0 20px 60px rgba(15, 20, 30, 0.12);
-  --radius: 20px;
+  --accent-2: #0071e3;
+  --accent-3: #d96a53;
+  --warm: #c9962e;
+  --card: rgba(255, 255, 255, 0.78);
+  --card-strong: rgba(255, 255, 255, 0.9);
+  --border: rgba(17, 20, 24, 0.08);
+  --shadow: 0 24px 72px rgba(15, 20, 30, 0.08);
+  --shadow-soft: 0 16px 42px rgba(15, 20, 30, 0.05);
+  --radius: 26px;
+  --heading-font: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Inter", "Helvetica Neue", Arial, sans-serif;
+  --body-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Inter", "Helvetica Neue", Arial, sans-serif;
 }
 
 * {
@@ -19,9 +24,12 @@
 
 body {
   margin: 0;
-  font-family: "Avenir Next", "Helvetica Neue", "Segoe UI", sans-serif;
+  font-family: var(--body-font);
   color: var(--ink-1);
-  background: radial-gradient(circle at top, var(--bg-2), var(--bg-1));
+  background:
+    radial-gradient(circle at top left, rgba(12, 127, 122, 0.12), transparent 28%),
+    radial-gradient(circle at top right, rgba(0, 113, 227, 0.08), transparent 24%),
+    linear-gradient(180deg, #fbfcfd, var(--bg-1));
   min-height: 100vh;
   overflow-x: hidden;
 }
@@ -29,7 +37,7 @@ body {
 h1,
 h2,
 h3 {
-  font-family: "Iowan Old Style", "Palatino Linotype", "Georgia", serif;
+  font-family: var(--heading-font);
   margin: 0;
 }
 
@@ -39,9 +47,9 @@ p {
 
 .shell {
   position: relative;
-  max-width: 1200px;
+  max-width: 1320px;
   margin: 0 auto;
-  padding: 48px 24px 80px;
+  padding: 32px 24px 88px;
   z-index: 1;
 }
 
@@ -57,8 +65,8 @@ p {
   width: 420px;
   height: 420px;
   border-radius: 50%;
-  filter: blur(0px);
-  opacity: 0.2;
+  filter: blur(16px);
+  opacity: 0.12;
   animation: float 16s ease-in-out infinite;
 }
 
@@ -85,31 +93,41 @@ p {
 .gridline {
   position: absolute;
   inset: 10% 8%;
-  border: 1px dashed rgba(12, 127, 122, 0.15);
-  border-radius: 32px;
+  border: 1px dashed rgba(12, 127, 122, 0.08);
+  border-radius: 36px;
 }
 
 .topbar {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 24px;
-  margin-bottom: 36px;
+  margin-bottom: 28px;
+  padding: 18px 20px;
+  border-radius: 28px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.68));
+  border: 1px solid rgba(255, 255, 255, 0.76);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(24px) saturate(160%);
+  position: sticky;
+  top: 14px;
+  z-index: 3;
 }
 
 .connection {
   font-size: 12px;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
-  padding: 6px 12px;
+  letter-spacing: 0.16em;
+  padding: 8px 12px;
   border-radius: 999px;
-  border: 1px solid rgba(15, 20, 30, 0.2);
+  border: 1px solid rgba(17, 20, 24, 0.1);
   color: var(--ink-2);
-  background: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.66);
+  font-weight: 650;
 }
 
 .connection--ok {
-  border-color: rgba(12, 127, 122, 0.4);
+  border-color: rgba(12, 127, 122, 0.2);
   color: var(--accent);
 }
 
@@ -127,34 +145,40 @@ p {
 }
 
 .brand h1 {
-  font-size: clamp(28px, 4vw, 44px);
+  font-size: clamp(34px, 4vw, 52px);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
 }
 
 .brand p {
   margin-top: 8px;
   color: var(--ink-2);
+  max-width: 620px;
+  line-height: 1.7;
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
-  letter-spacing: 0.12em;
+  font-size: 11px;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  padding: 6px 12px;
+  padding: 8px 12px;
   border-radius: 999px;
-  background: rgba(12, 127, 122, 0.12);
+  background: rgba(12, 127, 122, 0.08);
   color: var(--accent);
   margin-bottom: 12px;
+  font-weight: 650;
 }
 
 .actions {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 14px;
   flex-wrap: wrap;
   justify-content: flex-end;
+  padding: 8px 0 0;
 }
 
 .locale-picker {
@@ -162,9 +186,10 @@ p {
   gap: 6px;
   min-width: 148px;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   font-size: 11px;
   color: var(--muted);
+  font-weight: 650;
 }
 
 .locale-picker select {
@@ -172,32 +197,32 @@ p {
 }
 
 .btn {
-  border: none;
-  background: linear-gradient(120deg, var(--accent), #0aa6a0);
+  border: 1px solid transparent;
+  background: linear-gradient(120deg, var(--accent), #0f9187);
   color: #fff;
-  padding: 12px 22px;
-  min-height: 44px;
+  padding: 12px 20px;
+  min-height: 46px;
   border-radius: 999px;
   cursor: pointer;
-  font-weight: 600;
-  box-shadow: 0 12px 24px rgba(12, 127, 122, 0.2);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-weight: 650;
+  box-shadow: 0 12px 28px rgba(12, 127, 122, 0.16);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
 }
 
 .btn--ghost {
-  background: rgba(12, 127, 122, 0.08);
-  color: var(--accent);
-  box-shadow: none;
-  border: 1px solid rgba(12, 127, 122, 0.2);
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--ink-1);
+  box-shadow: 0 10px 24px rgba(15, 20, 30, 0.04);
+  border: 1px solid rgba(17, 20, 24, 0.08);
 }
 
 .btn--ghost:hover {
-  box-shadow: 0 12px 24px rgba(12, 127, 122, 0.16);
+  box-shadow: 0 14px 28px rgba(15, 20, 30, 0.06);
 }
 
 .btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 30px rgba(12, 127, 122, 0.28);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(12, 127, 122, 0.22);
 }
 
 button:disabled {
@@ -217,6 +242,7 @@ select:focus-visible {
 .timestamp {
   font-size: 14px;
   color: var(--muted);
+  padding: 0 4px;
 }
 
 .grid {
@@ -225,17 +251,71 @@ select:focus-visible {
   gap: 24px;
 }
 
+.grid-label {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 8px;
+  padding: 14px 18px;
+  max-width: 780px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(17, 20, 24, 0.05);
+  box-shadow: 0 12px 28px rgba(15, 20, 30, 0.04);
+}
+
+.grid-label__eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 650;
+}
+
+.grid-label__body {
+  margin: 0;
+  color: var(--ink-2);
+  line-height: 1.68;
+  font-size: 14px;
+}
+
+.grid > .grid-label:nth-of-type(1) {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(244, 252, 251, 0.7)),
+    radial-gradient(circle at top right, rgba(12, 127, 122, 0.08), transparent 48%);
+}
+
+.grid > .grid-label:nth-of-type(2) {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(247, 249, 253, 0.72)),
+    radial-gradient(circle at top right, rgba(0, 113, 227, 0.07), transparent 48%);
+}
+
+.grid > .grid-label:nth-of-type(3) {
+  background:
+    linear-gradient(180deg, rgba(19, 24, 34, 0.95), rgba(15, 20, 30, 0.9)),
+    radial-gradient(circle at top right, rgba(12, 127, 122, 0.16), transparent 55%);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 36px rgba(8, 12, 18, 0.18);
+}
+
+.grid > .grid-label:nth-of-type(3) .grid-label__eyebrow,
+.grid > .grid-label:nth-of-type(3) .grid-label__body {
+  color: rgba(255, 255, 255, 0.9);
+}
+
 .card {
   grid-column: span 4;
   background: var(--card);
   border-radius: var(--radius);
-  padding: 24px;
+  padding: 28px;
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(24px) saturate(160%);
   transform: translateY(12px);
   opacity: 0;
   animation: rise 0.8s ease forwards;
+  position: relative;
+  overflow: hidden;
 }
 
 .card:nth-child(1) { animation-delay: 0.05s; }
@@ -249,54 +329,207 @@ select:focus-visible {
 
 .card--focus {
   background:
-    linear-gradient(140deg, rgba(255, 255, 255, 0.92), rgba(236, 254, 255, 0.82)),
-    radial-gradient(circle at top right, rgba(34, 211, 238, 0.12), transparent 55%);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(245, 253, 252, 0.82)),
+    radial-gradient(circle at top right, rgba(12, 127, 122, 0.12), transparent 55%);
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(12, 127, 122, 0.28), rgba(0, 113, 227, 0.22), transparent 72%);
 }
 
 .card__header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   margin-bottom: 18px;
+  gap: 16px;
 }
 
 .card__intro {
   margin-bottom: 16px;
   color: var(--ink-2);
-  line-height: 1.6;
+  line-height: 1.7;
+}
+
+.card h2 {
+  font-size: clamp(24px, 2vw, 32px);
+  letter-spacing: -0.04em;
+  line-height: 1.02;
+}
+
+#operator-lane-card,
+#onboarding-card,
+#operator-focus-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(246, 253, 252, 0.82)),
+    radial-gradient(circle at top right, rgba(12, 127, 122, 0.12), transparent 54%);
+}
+
+#operator-lane-card::after,
+#operator-focus-card::after {
+  content: "";
+  position: absolute;
+  inset: auto -14% -24% 48%;
+  height: 180px;
+  background: radial-gradient(circle, rgba(0, 113, 227, 0.08), transparent 62%);
+  pointer-events: none;
+}
+
+#operator-lane-card .hint,
+#onboarding-card .hint {
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.64);
+  border: 1px solid rgba(17, 20, 24, 0.05);
+}
+
+#status-card .metrics {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+#actions-card .button-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+#schedule-card .form-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+#schedule-card .toggle {
+  grid-column: span 2;
+}
+
+#actions-card,
+#schedule-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(245, 252, 252, 0.8)),
+    radial-gradient(circle at top right, rgba(12, 127, 122, 0.1), transparent 50%);
+}
+
+#status-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(245, 252, 252, 0.8)),
+    radial-gradient(circle at top right, rgba(12, 127, 122, 0.1), transparent 52%);
+}
+
+#doctor-card,
+#access-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(248, 250, 252, 0.78)),
+    radial-gradient(circle at top right, rgba(0, 113, 227, 0.07), transparent 48%);
+}
+
+#recent-runs-card,
+#log-health-card,
+#metrics-card,
+#vendor-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(250, 251, 253, 0.76)),
+    radial-gradient(circle at top right, rgba(201, 150, 46, 0.05), transparent 44%);
+}
+
+#logs-card,
+#output-card {
+  background:
+    linear-gradient(180deg, rgba(18, 24, 34, 0.96), rgba(14, 19, 28, 0.9)),
+    radial-gradient(circle at top right, rgba(12, 127, 122, 0.18), transparent 55%);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 56px rgba(8, 12, 18, 0.22);
+}
+
+#logs-card + #output-card,
+#output-card {
+  margin-top: -4px;
+}
+
+#logs-card::before,
+#output-card::before {
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.28), rgba(0, 113, 227, 0.24), transparent 76%);
+}
+
+#logs-card h2,
+#output-card h2,
+#logs-card .card__intro,
+#output-card .card__intro,
+#logs-card .console-meta__copy strong,
+#logs-card .console-meta__copy p,
+#logs-card .console-meta__hint,
+#output-card #output-context,
+#output-card #output-guidance,
+#logs-card label,
+#logs-card .hint,
+#output-card .hint {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+#logs-card select,
+#logs-card input {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+#logs-card .console-meta {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+#logs-card .table-row,
+#output-card .table-row,
+#logs-card .list li,
+#output-card .list li {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.86);
+}
+
+#logs-card .btn--ghost,
+#output-card .btn--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.92);
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
 }
 
 .focus-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
+  gap: 18px;
 }
 
 .focus-card {
   display: grid;
   gap: 10px;
-  padding: 18px;
-  border-radius: 18px;
-  border: 1px solid rgba(12, 127, 122, 0.12);
+  padding: 20px;
+  border-radius: 22px;
+  border: 1px solid rgba(17, 20, 24, 0.06);
   background: rgba(255, 255, 255, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.56);
 }
 
 .focus-card--priority {
-  background: linear-gradient(180deg, rgba(12, 127, 122, 0.12), rgba(255, 255, 255, 0.82));
-  border-color: rgba(12, 127, 122, 0.22);
+  background: linear-gradient(180deg, rgba(12, 127, 122, 0.1), rgba(255, 255, 255, 0.82));
+  border-color: rgba(12, 127, 122, 0.14);
 }
 
 .focus-card__label {
   font-size: 11px;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--muted);
+  font-weight: 650;
 }
 
 .focus-card__value {
-  font-size: 20px;
-  line-height: 1.35;
+  font-size: 22px;
+  line-height: 1.2;
   color: var(--ink-1);
+  letter-spacing: -0.03em;
 }
 
 .focus-card__body {
@@ -319,48 +552,56 @@ select:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--muted);
+  padding: 16px 18px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.66);
+  border: 1px solid rgba(17, 20, 24, 0.05);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 .metric strong {
-  font-size: 18px;
+  font-size: 20px;
   color: var(--ink-1);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
 }
 
 .metric--step {
-  padding: 14px;
-  border-radius: 16px;
-  background: rgba(12, 127, 122, 0.08);
+  padding: 18px;
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(12, 127, 122, 0.08), rgba(255, 255, 255, 0.78));
   border: 1px solid rgba(12, 127, 122, 0.12);
 }
 
 .metric__body {
   margin: 0;
   color: var(--ink-2);
-  line-height: 1.5;
+  line-height: 1.65;
 }
 
 .pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 6px 14px;
+  padding: 7px 14px;
   border-radius: 999px;
-  font-size: 12px;
-  letter-spacing: 0.08em;
+  font-size: 11px;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  background: rgba(12, 127, 122, 0.12);
+  background: rgba(12, 127, 122, 0.08);
   color: var(--accent);
+  font-weight: 650;
 }
 
 .pill--warn {
-  background: rgba(240, 180, 41, 0.18);
-  color: #9c6d00;
+  background: rgba(201, 150, 46, 0.14);
+  color: #8d6310;
 }
 
 .pill--fail {
-  background: rgba(231, 111, 81, 0.18);
+  background: rgba(217, 106, 83, 0.14);
   color: #9d2e13;
 }
 
@@ -371,12 +612,13 @@ select:focus-visible {
 
 .callout {
   margin-top: 16px;
-  padding: 12px 14px;
-  border-radius: 14px;
-  background: rgba(231, 111, 81, 0.12);
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(217, 106, 83, 0.12);
   color: #8d2a13;
   font-size: 13px;
   display: none;
+  border: 1px solid rgba(217, 106, 83, 0.14);
 }
 
 .phases {
@@ -391,10 +633,11 @@ select:focus-visible {
 
 .list-wrap h3 {
   margin-bottom: 8px;
-  font-size: 14px;
-  letter-spacing: 0.08em;
+  font-size: 12px;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--muted);
+  font-weight: 650;
 }
 
 .phase-bar {
@@ -453,9 +696,10 @@ select:focus-visible {
 }
 
 .list li {
-  padding: 10px 12px;
-  border-radius: 12px;
-  background: rgba(12, 127, 122, 0.08);
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(17, 20, 24, 0.05);
 }
 
 .table {
@@ -469,9 +713,10 @@ select:focus-visible {
   display: grid;
   grid-template-columns: 160px 1fr 120px;
   gap: 12px;
-  padding: 10px 14px;
-  border-radius: 12px;
-  background: rgba(12, 127, 122, 0.08);
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(17, 20, 24, 0.05);
 }
 
 .table-row strong {
@@ -480,7 +725,7 @@ select:focus-visible {
 
 .button-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
 }
 
@@ -497,10 +742,10 @@ select:focus-visible {
   justify-content: space-between;
   gap: 18px;
   margin-bottom: 14px;
-  padding: 16px 18px;
-  border-radius: 16px;
-  background: rgba(12, 127, 122, 0.07);
-  border: 1px solid rgba(12, 127, 122, 0.12);
+  padding: 18px 20px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(17, 20, 24, 0.05);
 }
 
 .console-meta__copy {
@@ -510,7 +755,8 @@ select:focus-visible {
 
 .console-meta__copy strong {
   color: var(--ink-1);
-  font-size: 15px;
+  font-size: 16px;
+  letter-spacing: -0.01em;
 }
 
 .console-meta__copy p,
@@ -544,21 +790,23 @@ select:focus-visible {
 label {
   display: grid;
   gap: 6px;
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.16em;
   color: var(--muted);
+  font-weight: 650;
 }
 
 input,
 select {
-  padding: 10px 12px;
-  border-radius: 12px;
-  border: 1px solid rgba(15, 20, 30, 0.15);
-  background: rgba(255, 255, 255, 0.8);
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(17, 20, 24, 0.1);
+  background: rgba(255, 255, 255, 0.84);
   font-size: 14px;
   color: var(--ink-1);
-  font-family: "Avenir Next", "Helvetica Neue", "Segoe UI", sans-serif;
+  font-family: var(--body-font);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .toggle {
@@ -580,14 +828,14 @@ select {
   margin: 0;
   min-height: 220px;
   max-height: 440px;
-  padding: 18px 20px;
-  border-radius: 18px;
+  padding: 20px 22px;
+  border-radius: 22px;
   background:
-    linear-gradient(180deg, rgba(15, 23, 42, 0.96), rgba(15, 23, 42, 0.88)),
-    radial-gradient(circle at top, rgba(34, 211, 238, 0.14), transparent 55%);
+    linear-gradient(180deg, rgba(17, 23, 33, 0.96), rgba(17, 23, 33, 0.9)),
+    radial-gradient(circle at top, rgba(12, 127, 122, 0.12), transparent 55%);
   color: #d7f9f5;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 20px 42px rgba(17, 23, 33, 0.16);
   font-family: "SFMono-Regular", "Menlo", "Monaco", monospace;
   font-size: 13px;
   line-height: 1.72;
@@ -613,6 +861,9 @@ select {
   .metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+  #status-card .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
   .doctor-grid {
     grid-template-columns: 1fr;
   }
@@ -630,6 +881,12 @@ select {
   }
   .console-meta {
     flex-direction: column;
+  }
+  #schedule-card .form-grid {
+    grid-template-columns: 1fr;
+  }
+  #schedule-card .toggle {
+    grid-column: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- refresh the public/runtime surfaces for the Apple Notes snapshot control room
- tighten launchd schedule/watchpaths E2E coverage and waiting logic
- keep the server/web/docs surfaces aligned with the repaired launchd path

## Verification
- python3 -m pytest -q
- python3 -m pytest -q tests/e2e/test_e2e_launchd_watchpaths.py::LaunchdWatchPathsE2ETests::test_watch_paths_trigger_run
- python3 -m pytest -q tests/e2e/test_e2e_launchd_schedule.py::LaunchdScheduleE2ETests::test_launchd_schedule_triggers_second_run tests/e2e/test_e2e_launchd_watchpaths.py::LaunchdWatchPathsE2ETests::test_watch_paths_trigger_run