### PR TITLE
tighten public docs and release language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # Apple Notes Snapshot
 
-Apple Notes Snapshot is the local-first backup control room for Apple Notes on
+Apple Notes Snapshot is the backup control room for Apple Notes on
 macOS. Keep the upstream `notes-exporter` engine, then add path-aware exports,
 `launchd` scheduling, visible health checks, and a calmer recovery path when
 the local backup loop drifts.
 
-Second ring only: after the control room already makes sense, the repo also
-ships **AI-assisted diagnostics**, a **token-gated Local Web API**, and a
-**stdio-first MCP surface** so humans and MCP-aware coding agents can inspect
-the same local backup state without turning the workflow into a hosted
-service.
+After the control room already makes sense, the repo also ships extra builder
+and diagnostics surfaces so humans and coding agents can inspect the same
+backup state without turning the workflow into a hosted service.
 
 [Start the 3-step quickstart](https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/) |
 [First-run troubleshooting](https://xiaojiou176-open.github.io/apple-notes-snapshot/troubleshooting/) |
@@ -33,9 +31,8 @@ service.
 - **Read the next safe move first**
   The Web console now surfaces an operator focus deck above the raw transcript so you can see the next move, the reason, and the reading order before diving into action output.
 
-> Category: local-first Apple Notes backup control room.
-> AI/agent hook: AI-assisted diagnostics plus a token-gated Local Web API and
-> a read-only MCP surface for MCP-aware coding agents.
+> Category: Apple Notes backup control room.
+> AI/agent hook: AI-assisted diagnostics plus optional coding-agent access once the operator workflow is already clear.
 > Result: a calmer, more reviewable backup workflow on your own Mac.
 
 > Best fit: people who already rely on Apple Notes and want a calmer,
@@ -51,7 +48,7 @@ table first:
 
 | What you need to know | Current answer |
 | --- | --- |
-| Product thesis | a local-first Apple Notes backup control room for macOS |
+| Product thesis | an Apple Notes backup control room for macOS |
 | First success | `./notesctl run --no-status` -> `./notesctl install --minutes 30 --load` -> `./notesctl verify` |
 | First proof surface | the proof page after one healthy local loop exists |
 | Second ring only | AI Diagnose, Local Web API, and MCP come after the operator path already makes sense |
@@ -62,12 +59,12 @@ table first:
 - **The destination is obvious**: you can review or override the snapshot path before anything writes.
 - **The loop is real**: one manual run plus `launchd` turns a one-off export into a repeatable local rhythm.
 - **The control room is inspectable**: `status`, `verify`, `doctor`, logs, and proof pages all stay on the same local facts.
-- **Builder surfaces are optional**: AI Diagnose, the Local Web API, and MCP all stay behind the operator story instead of replacing it.
+- **Integration surfaces are optional**: AI Diagnose, the Local Web API, and MCP all stay behind the operator story instead of replacing it.
 
 If you want the shortest public evidence trail after that first pass, open the
 [proof page](https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/).
 It collects the repo-owned gates, the GitHub-controlled release and Pages
-evidence, and the current same-machine boundary in one place.
+evidence, and the current access boundary in one place.
 
 ## Start with Run -> Install -> Verify
 
@@ -88,7 +85,7 @@ After that verified loop exists, the Web console, proof page, AI Diagnose,
 Local Web API, and MCP surfaces become much easier to read because they are all
 describing a baseline you already proved.
 
-## Builder and maintainer lanes after the operator path
+## Integration and maintainer routes after the operator path
 
 The public product front door is still the local backup control room. The lanes
 below are for builders after the first healthy loop exists; they do not replace
@@ -116,14 +113,14 @@ below are for builders after the first healthy loop exists; they do not replace
     read-back
   - no cross-machine attach guarantee
 
-Use the builder links below only after the operator loop already makes sense.
+Use the integration links below only after the operator loop already makes sense.
 
-Secondary builder reads after the first healthy loop:
+Secondary integration reads after the first healthy loop:
 [AI Diagnose](https://xiaojiou176-open.github.io/apple-notes-snapshot/ai-diagnose/) |
 [Local Web API](https://xiaojiou176-open.github.io/apple-notes-snapshot/local-api/) |
 [MCP Provider](https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/) |
 [Distribution and listing boundaries](./DISTRIBUTION.md) |
-[For Codex / Claude Code builders](https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/)
+[For Codex / Claude Code integrations](https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/)
 
 ## Quickstart
 
@@ -199,8 +196,8 @@ Apple Notes Snapshot wraps the upstream exporter with:
 
 ## What you get over upstream notes-exporter
 
-Think of upstream as the engine and this repository as the local control room
-around it. The wrapper stays local-first, tells you where snapshots will land,
+Think of upstream as the engine and this repository as the control room
+around it. The wrapper tells you where snapshots will land,
 and makes the schedule and health surface easier to inspect when something
 breaks.
 
@@ -262,8 +259,8 @@ replace `notesctl` or the deterministic runtime checks.
 
 ## How AI and agents fit
 
-Use this mental model if you care about Codex, Claude Code, MCP, or other local
-builder ecosystems.
+Use this mental model if you care about Codex, Claude Code, MCP, or other
+host-local integration ecosystems.
 
 Natural fit:
 
@@ -277,18 +274,18 @@ Natural fit:
   - It exposes the same local backup state to MCP-aware hosts.
   - It does not turn the project into a hosted agent platform or write-capable
     remote control plane.
-- **Local Web API = token-gated browser/API lane**
+- **Local Web API = token-gated browser/API surface**
   - It serves the local Web console plus JSON endpoints like `status`,
     `doctor`, `recent-runs`, and `access`.
-  - It is meant for same-machine browser or local HTTP workflows, not as a
+  - It is meant for browser or local HTTP workflows on your own machine, not as a
     public OpenAPI promise.
-- **`notesctl` + `state.json` + aggregate summaries + token-gated Web API = current local substrate**
+- **`notesctl` + `state.json` + aggregate summaries + token-gated Web API = current substrate**
   - This repository does not ship a public OpenAPI, generated client, or SDK
     today.
-  - The truthful builder entry points are the CLI contract, the token-gated
-    local Web API, and the read-only MCP surface.
+  - The truthful integration entry points are the CLI contract, the web/API
+    surface, and the read-only MCP surface.
 
-The builder lane has its own shelves now, so this README does not need to carry
+Integration-facing docs have their own shelves now, so this README does not need to carry
 every host-specific setup detail:
 
 - Open the public
@@ -367,8 +364,8 @@ required for the first successful snapshot.
 
 If you want the shorter public-facing evidence page first, open the
 [proof page](https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/).
-It keeps the repo-side gates, GitHub-controlled delivery facts, and live
-same-machine boundary in one place. The ladder below remains the
+It keeps the repo-side gates, GitHub-controlled delivery facts, and the
+current access boundary in one place. The ladder below remains the
 maintainer-grade verification contract.
 
 Default local maintainer lane:
@@ -590,7 +587,7 @@ Read the pyramid as:
 
 ## Security and privacy
 
-This project is intentionally local-first:
+This project is intentionally user-controlled on your own machine:
 
 - your Apple Notes content stays in your own Apple Notes account and export
   destination

--- a/docs/adr/0001-closeout-canonical-and-hard-cut-threshold.md
+++ b/docs/adr/0001-closeout-canonical-and-hard-cut-threshold.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-Apple Notes Snapshot is a local-first wrapper around a vendored upstream engine.
+Apple Notes Snapshot is a local backup wrapper around a vendored upstream engine.
 The repository currently ships a CLI contract, a token-gated local Web API, a
 read-only MCP surface, and public documentation, but it does **not** ship a
 public OpenAPI, generated SDK, or public schema package.

--- a/docs/ai-diagnose/index.html
+++ b/docs/ai-diagnose/index.html
@@ -6,7 +6,7 @@
     <title>AI Diagnose | Apple Notes Snapshot</title>
     <meta
       name="description"
-      content="Use AI Diagnose as an opt-in, advisory sidecar for Apple Notes Snapshot. It reads local status and diagnostics, not exported note content."
+      content="Use AI Diagnose as an opt-in, advisory diagnostics layer for Apple Notes Snapshot. It reads local status and diagnostics, not exported note content."
     />
     <link rel="canonical" href="https://xiaojiou176-open.github.io/apple-notes-snapshot/ai-diagnose/" />
     <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
@@ -16,11 +16,11 @@
     <meta property="og:title" content="AI Diagnose | Apple Notes Snapshot" />
     <meta
       property="og:description"
-      content="Use AI Diagnose as an opt-in, advisory sidecar for Apple Notes Snapshot. It reads local status and diagnostics, not exported note content."
+      content="Use AI Diagnose as an opt-in, advisory diagnostics layer for Apple Notes Snapshot. It reads local status and diagnostics, not exported note content."
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/ai-diagnose/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot AI Diagnose page for the local-first advisory diagnosis sidecar" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot AI Diagnose page for the advisory diagnostics layer" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="AI Diagnose for Apple Notes Snapshot" />
     <meta
@@ -67,7 +67,7 @@
       <main id="main-content">
       <section class="page-hero">
         <span class="page-hero__eyebrow">Opt-in and advisory</span>
-        <h1>Use AI Diagnose as a local sidecar, not as the system truth.</h1>
+        <h1>Use AI Diagnose as an advisory diagnostics layer, not as the system truth.</h1>
         <p>
           AI Diagnose reads the existing local diagnostics surface and turns it into a more human
           explanation. It does not replace <code>status</code>, <code>doctor</code>,

--- a/docs/compare/index.html
+++ b/docs/compare/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/compare/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot compare card for the local-first Apple Notes backup control room" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot compare card for the Apple Notes backup control room" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Compare Apple Notes Snapshot with upstream" />
     <meta
@@ -124,7 +124,7 @@
               <td>Yes, a read-only MCP contract is useful</td>
             </tr>
             <tr>
-              <td>Do you want a token-gated same-machine browser/API lane?</td>
+              <td>Do you want a token-gated browser/API lane on your own machine?</td>
               <td>No, CLI plus logs are enough</td>
               <td>Yes, the Local Web API is useful</td>
             </tr>
@@ -157,9 +157,9 @@
       <section class="page-card page-card--warm">
         <h2>Optional second lane after the control room</h2>
         <p>
-          Once the operator fit is already obvious, the repo also adds three builder-facing
+          Once the operator fit is already obvious, the repo also adds three integration-facing
           surfaces around the same local facts: <strong>AI Diagnose</strong> for advisory
-          explanation, a <strong>token-gated Local Web API</strong> for same-machine browser or
+          explanation, a <strong>token-gated Local Web API</strong> for browser or
           HTTP workflows, and a <strong>read-only-first MCP surface</strong> for agent hosts.
         </p>
         <p>

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -6,7 +6,7 @@
     <title>Common Apple Notes Snapshot questions answered | FAQ</title>
     <meta
       name="description"
-      content="Answers to common Apple Notes Snapshot questions about local-first behavior, launchd scheduling, the Local Web API, AI Diagnose, MCP, privacy, and upstream notes-exporter."
+      content="Answers to common Apple Notes Snapshot questions about launchd scheduling, the Local Web API, AI Diagnose, MCP, privacy, and upstream notes-exporter."
     />
     <link rel="canonical" href="https://xiaojiou176-open.github.io/apple-notes-snapshot/faq/" />
     <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
@@ -16,16 +16,16 @@
     <meta property="og:title" content="FAQ | Apple Notes Snapshot" />
     <meta
       property="og:description"
-      content="Answers to common Apple Notes Snapshot questions about local-first behavior, launchd scheduling, the Local Web API, AI Diagnose, MCP, privacy, and upstream notes-exporter."
+      content="Answers to common Apple Notes Snapshot questions about launchd scheduling, the Local Web API, AI Diagnose, MCP, privacy, and upstream notes-exporter."
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/faq/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot FAQ card answering common questions about the local-first backup control room" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot FAQ card answering common questions about the backup control room" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Common Apple Notes Snapshot questions answered" />
     <meta
       name="twitter:description"
-      content="Answers to common Apple Notes Snapshot questions about local-first behavior, launchd scheduling, the Local Web API, AI Diagnose, MCP, privacy, and upstream notes-exporter."
+      content="Answers to common Apple Notes Snapshot questions about launchd scheduling, the Local Web API, AI Diagnose, MCP, privacy, and upstream notes-exporter."
     />
     <meta name="twitter:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
     <link rel="stylesheet" href="../styles.css" />
@@ -81,7 +81,7 @@
             "name": "What is the difference between the Local Web API and MCP?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "The Local Web API comes from ./notesctl web and is a token-gated same-machine browser and HTTP surface. MCP comes from ./notesctl mcp and is a stdio-first host-to-tooling contract for MCP-aware agents. Neither is a public OpenAPI or hosted control plane."
+              "text": "The Local Web API comes from ./notesctl web and is a token-gated browser and HTTP surface on your own machine. MCP comes from ./notesctl mcp and is a stdio-first host-to-tooling contract for MCP-aware agents. Neither is a public OpenAPI or hosted control plane."
             }
           },
           {
@@ -166,7 +166,7 @@
           <h3>What is the difference between the Local Web API and MCP?</h3>
           <p>
             The <a href="../local-api/">Local Web API</a> comes from <code>./notesctl web</code>
-            and is a token-gated same-machine browser and HTTP surface. The
+            and is a token-gated browser and HTTP surface on this Mac. The
             <a href="../mcp/">MCP Provider</a> comes from <code>./notesctl mcp</code> and is a
             stdio-first host-to-tooling contract for MCP-aware agents. Neither one is a public
             OpenAPI or hosted control plane.
@@ -202,8 +202,9 @@
         <article class="faq-item">
           <h3>Can I expose the Web console remotely?</h3>
           <p>
-            The project is designed to stay local-first. If you deliberately bind it beyond loopback,
-            set a strong token, review the action allowlist, and read the security summary first.
+            The project is designed to stay loopback-first. If you deliberately bind it beyond
+            loopback, set a strong token, review the action allowlist, and read the security
+            summary first.
           </p>
         </article>
       </section>
@@ -231,7 +232,7 @@
       <footer class="footer">
         If your question is really "should I use this or upstream?", go to the
         <a href="../compare/">comparison page</a>. If your question is "how do I start?",
-        use the <a href="../quickstart/">quickstart</a>. If your question is "which builder/API
+        use the <a href="../quickstart/">quickstart</a>. If your question is "which integration/API
         surface fits me?", open <a href="../local-api/">Local Web API</a> or
         <a href="../for-agents/">For Agents</a>. If your question is "what should I post next?",
         use the <a href="../media/external-launch-prep/">external launch prep packet</a>.

--- a/docs/for-agents/index.html
+++ b/docs/for-agents/index.html
@@ -16,11 +16,11 @@
     <meta property="og:title" content="For Codex, Claude Code, and other MCP-aware hosts | Apple Notes Snapshot" />
     <meta
       property="og:description"
-      content="Apple Notes Snapshot is a local-first Apple Notes backup control room with a local Web API, AI Diagnose, and a read-only MCP surface for Codex, Claude Code, and other MCP-aware hosts."
+      content="Apple Notes Snapshot is an Apple Notes backup control room with a Local Web API, AI Diagnose, and a read-only MCP surface for Codex, Claude Code, and other MCP-aware hosts."
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot for agents page describing the AI Diagnose sidecar and MCP provider" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot for agents page describing AI Diagnose and the MCP provider" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="For Codex, Claude Code, and other MCP-aware hosts | Apple Notes Snapshot" />
     <meta
@@ -65,12 +65,12 @@
 
       <main id="main-content">
       <section class="page-hero">
-        <span class="page-hero__eyebrow">Builder lane, still downstream of the control room</span>
-        <h1>Give local coding hosts the same backup facts as a human operator.</h1>
+        <span class="page-hero__eyebrow">Coding-host route, still downstream of the control room</span>
+        <h1>Give coding hosts the same backup facts as a human operator.</h1>
         <p>
           The project is not a hosted agent platform. It is a local Apple Notes backup control room
-          with three truthful builder surfaces: a token-gated same-machine Local Web API, an
-          advisory AI diagnosis sidecar, and a stdio-first, read-only-first MCP provider.
+          with three truthful host surfaces: a token-gated Local Web API for this Mac, an advisory
+          AI Diagnose surface, and a stdio-first, read-only-first MCP provider.
         </p>
       </section>
 
@@ -78,7 +78,7 @@
         <article class="curation-card">
           <span class="eyebrow-inline">Step 1</span>
           <strong>Understand the control room.</strong>
-          <p>Builder work starts from the deterministic CLI and state ledger, not from agent marketing language.</p>
+          <p>Host integration starts from the deterministic CLI and state ledger, not from agent marketing language.</p>
         </article>
         <article class="curation-card">
           <span class="eyebrow-inline">Step 2</span>
@@ -87,7 +87,7 @@
         </article>
         <article class="curation-card">
           <span class="eyebrow-inline">Step 3</span>
-          <strong>Choose the right builder surface.</strong>
+          <strong>Choose the right host surface.</strong>
           <p>Local Web API, AI Diagnose, and MCP each solve a different problem. This page exists to keep them separate.</p>
         </article>
       </section>
@@ -98,14 +98,14 @@
           Start with the <a href="../quickstart/">quickstart</a>, the
           <a href="../compare/">compare page</a>, or the
           <a href="../proof/">proof page</a> if you still need the control-room contract first.
-          This page is the builder second lane, not the first thing every visitor needs to open.
+          This page is the integration second lane, not the first thing every visitor needs to open.
         </p>
       </section>
 
       <section class="page-card page-card--warm">
         <h2>Start here by goal</h2>
         <ul>
-          <li><strong>Need the shared host matrix first?</strong> Open the <a href="./integration-pack/">Builder Integration Pack</a>.</li>
+          <li><strong>Need the shared host matrix first?</strong> Open the <a href="./integration-pack/">Integration Pack</a>.</li>
           <li><strong>Need the shortest install path?</strong> Open the Codex, Claude Code, or OpenClaw starter pack that matches your host.</li>
           <li><strong>Need reusable prompt or listing-safe guidance?</strong> Open the <a href="./public-skills/">public skills pack</a> and the standalone skill packet.</li>
         </ul>
@@ -121,7 +121,7 @@
           <li><strong>Comparison-only</strong>: this repo mentions the host only to mark scope and avoid overclaiming.</li>
         </ul>
         <p>
-          Read this legend first, then use the <a href="./integration-pack/">Builder Integration Pack</a>
+          Read this legend first, then use the <a href="./integration-pack/">Integration Pack</a>
           or the host-specific starter packs so you do not accidentally upgrade guidance into a
           support claim.
         </p>
@@ -176,7 +176,7 @@
         <h2>Current builder entry points you can trust</h2>
         <ul>
           <li><strong>Deterministic CLI reads</strong>: <code>./notesctl status --json</code>, <code>./notesctl doctor --json</code>, <code>./notesctl log-health --json</code>, and <code>./notesctl aggregate --tail N</code></li>
-          <li><strong>Token-gated local browser/API lane</strong>: <code>./notesctl web</code> when your local workflow wants the Web console plus the same-machine JSON endpoints behind a local token gate</li>
+          <li><strong>Token-gated local browser/API lane</strong>: <code>./notesctl web</code> when your local workflow wants the Web console plus JSON endpoints on this Mac behind a local token gate</li>
           <li><strong>Advisory CLI layer</strong>: <code>./notesctl ai-diagnose --json</code> when you want a calmer explanation around the same local facts</li>
           <li><strong>Agent substrate</strong>: <code>./notesctl mcp</code> when your host can launch stdio MCP servers</li>
         </ul>
@@ -195,8 +195,8 @@
       <section class="page-card page-card--warm">
         <h2>Need the copy-paste pack?</h2>
         <p>
-          Open the <a href="./integration-pack/">Builder Integration Pack</a> when you want one
-          page with the capability matrix, same-machine contract, host status table, repo-owned
+          Open the <a href="./integration-pack/">Integration Pack</a> when you want one
+          page with the capability matrix, host-local contract, host status table, repo-owned
           copyable examples, and a short post-attach checklist that separates repo-side proof from
           host-side proof.
         </p>
@@ -232,7 +232,7 @@
           <li><code>./notesctl help mcp</code> for the narrow MCP contract</li>
           <li><code>./notesctl help web</code> for the browser plus Local Web API contract</li>
           <li><code>./notesctl help audit</code> for token, scope, allowlist, readonly, and rate-limit rules</li>
-          <li><code>./notesctl help ai-diagnose</code> for the advisory AI sidecar contract</li>
+          <li><code>./notesctl help ai-diagnose</code> for the advisory AI Diagnose contract</li>
         </ul>
       </section>
 
@@ -265,7 +265,7 @@
       <section class="page-card">
         <h2>Where to start</h2>
         <ul>
-          <li>Read <a href="./integration-pack/">Builder Integration Pack</a> if you want the copyable host matrix and setup examples first</li>
+          <li>Read <a href="./integration-pack/">Integration Pack</a> if you want the copyable host matrix and setup examples first</li>
           <li>Read <a href="./codex-starter-pack/">Codex Starter Pack</a> if you want the narrow project-scoped Codex setup surface</li>
           <li>Read <a href="./claude-code-starter-pack/">Claude Code Starter Pack</a> if you want the project-scoped versus user-scoped Claude setup surface</li>
           <li>Read <a href="./openclaw-starter-pack/">OpenClaw Starter Pack</a> if you want the narrow MCP registry path for OpenClaw</li>

--- a/docs/for-agents/integration-pack/index.html
+++ b/docs/for-agents/integration-pack/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Builder Integration Pack | Apple Notes Snapshot</title>
+    <title>Integration Pack | Apple Notes Snapshot</title>
     <meta
       name="description"
       content="Choose the right Apple Notes Snapshot surface and copy minimal setup examples for Codex, Claude Code, MCP, and the Local Web API."
@@ -13,16 +13,16 @@
     <link rel="manifest" href="../../site.webmanifest" />
     <meta name="theme-color" content="#0e7c74" />
     <meta property="og:type" content="article" />
-    <meta property="og:title" content="Builder Integration Pack | Apple Notes Snapshot" />
+    <meta property="og:title" content="Integration Pack | Apple Notes Snapshot" />
     <meta
       property="og:description"
-      content="Capability matrix, same-machine contract, and copyable setup examples for Codex, Claude Code, MCP-aware hosts, and the Local Web API."
+      content="Capability matrix, host-local contract, and copyable setup examples for Codex, Claude Code, MCP-aware hosts, and the Local Web API."
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/integration-pack/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
     <meta property="og:image:alt" content="Apple Notes Snapshot builder integration pack page with capability matrix and host setup examples" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Builder Integration Pack | Apple Notes Snapshot" />
+    <meta name="twitter:title" content="Integration Pack | Apple Notes Snapshot" />
     <meta
       name="twitter:description"
       content="Copyable, truthful setup examples for the Apple Notes Snapshot CLI, Local Web API, AI Diagnose, and MCP surfaces."
@@ -47,7 +47,7 @@
       <nav class="site-nav" aria-label="Primary">
         <div class="site-nav__brand">
           <span class="site-nav__eyebrow">Apple Notes Snapshot</span>
-          <span class="site-nav__title">Builder Integration Pack</span>
+          <span class="site-nav__title">Integration Pack</span>
         </div>
         <div class="site-nav__links">
           <a href="../../">Home</a>
@@ -65,18 +65,18 @@
         <span class="page-context__divider" aria-hidden="true">/</span>
         <a href="../">For Agents</a>
         <span class="page-context__divider" aria-hidden="true">/</span>
-        <span aria-current="page">Builder Integration Pack</span>
+        <span aria-current="page">Integration Pack</span>
       </nav>
 
 
       <main id="main-content">
       <section class="page-hero">
-        <span class="page-hero__eyebrow">Copyable, same-machine, and truthful</span>
+        <span class="page-hero__eyebrow">Copyable, host-local, and truthful</span>
         <h1>Use this pack when you want the shortest honest path into a local coding host.</h1>
         <p>
           This pack does not invent a hosted platform story. It packages what the repository
           already ships today: deterministic CLI reads, an advisory AI Diagnose layer, a
-          token-gated same-machine Local Web API, and a stdio-first, read-only-first MCP surface.
+          token-gated Local Web API for this Mac, and a stdio-first, read-only-first MCP surface.
         </p>
       </section>
 
@@ -86,7 +86,7 @@
           <li>Review <code>config/notes_snapshot.env</code> so the repo knows where snapshots and state should live.</li>
           <li>Run <code>./notesctl run --no-status</code> at least once so Apple Notes permissions and the first local state record exist.</li>
           <li>Run <code>./notesctl verify</code> and <code>./notesctl doctor --json</code> so your host is reading real local state, not a first-run missing-state wrapper.</li>
-          <li>Choose the builder lane that matches your workflow shape: CLI, Local Web API, AI Diagnose, or MCP.</li>
+          <li>Choose the host surface that matches your workflow shape: CLI, Local Web API, AI Diagnose, or MCP.</li>
         </ol>
       </section>
 
@@ -123,7 +123,7 @@
             <tr>
               <td><strong>Local Web API</strong></td>
               <td><code>./notesctl web --host 127.0.0.1 --port 8080</code></td>
-              <td>Same-machine HTTP behind a token gate</td>
+              <td>Host-local HTTP behind a token gate</td>
               <td>Browser-backed local tooling and local HTTP consumers</td>
               <td>Read endpoints plus access-policy reads are the safest builder contract today</td>
               <td>No public OpenAPI, no hosted API, no default remote exposure</td>
@@ -214,10 +214,10 @@
             <tr>
               <td><strong>Browser-backed or HTTP-shaped local tool</strong></td>
               <td>Yes</td>
-              <td>Repo-side proven for same-machine reads</td>
+              <td>Repo-side proven for host-local reads</td>
               <td><code>./notesctl web</code> plus a local token</td>
               <td><a href="https://github.com/xiaojiou176-open/apple-notes-snapshot/blob/main/examples/integration-pack/local-web-api.env.example">Local Web API env example</a> and <a href="https://github.com/xiaojiou176-open/apple-notes-snapshot/blob/main/examples/integration-pack/local-web-api.curl.sh">curl example</a></td>
-              <td>That you keep the surface same-machine, token-gated, and loopback-first</td>
+              <td>That you keep the surface host-local, token-gated, and loopback-first</td>
             </tr>
           </tbody>
         </table>
@@ -226,7 +226,7 @@
       <section class="page-card">
         <h2>Repo proof vs host-side proof</h2>
         <ul>
-          <li><strong>Repo-side already proven here</strong>: the CLI contract, the same-machine Local Web API contract, the stdio MCP launch shape, and the current read-only tool/resource surface.</li>
+          <li><strong>Repo-side already proven here</strong>: the CLI contract, the Local Web API contract for this Mac, the stdio MCP launch shape, and the current read-only tool/resource surface.</li>
           <li><strong>Named-host status today</strong>: Claude Code, Codex, and OpenClaw each have a tagged host-proof trail in <a href="../../releases/v0.1.12/">v0.1.12</a>; OpenCode stays template-only and OpenHands stays comparison-only.</li>
           <li><strong>Host-side still yours to verify on another machine</strong>: where your host stores config, whether attach succeeds in that host build, and any extra host-specific options or UI steps outside the current verified machine.</li>
           <li><strong>Truthful attach rule</strong>: keep OpenCode template-only and OpenHands comparison-only, and do not generalize one tagged named-host proof trail into a universal guarantee for every machine or release.</li>
@@ -311,7 +311,7 @@
             <tr>
               <td><strong>Generic MCP examples</strong></td>
               <td>Any host that speaks stdio MCP</td>
-              <td>Launch shape, checklist, and same-machine contract</td>
+              <td>Launch shape, checklist, and host-local contract</td>
               <td>No hosted runtime, no remote MCP, no write-capable automation platform</td>
             </tr>
           </tbody>
@@ -324,7 +324,7 @@
           <li><code>./notesctl help mcp</code> for the narrow MCP contract</li>
           <li><code>./notesctl help web</code> for the browser plus Local Web API contract</li>
           <li><code>./notesctl help audit</code> for token, scope, allowlist, readonly, and rate-limit rules</li>
-          <li><code>./notesctl help ai-diagnose</code> for the advisory AI sidecar contract</li>
+          <li><code>./notesctl help ai-diagnose</code> for the advisory AI Diagnose contract</li>
         </ul>
       </section>
 
@@ -397,8 +397,8 @@
       </main>
 
       <footer class="footer">
-        Keep the story narrow and honest: same-machine backup control room first, builder-friendly
-        integration pack second, hosted platform claims out of scope.
+        Keep the story narrow and honest: backup control room first, host integration pack second,
+        hosted platform claims out of scope.
       </footer>
     </div>
   </body>

--- a/docs/for-agents/public-skills/index.html
+++ b/docs/for-agents/public-skills/index.html
@@ -277,8 +277,8 @@
       <section class="page-card">
         <h2>What to pair with this pack</h2>
         <ul>
-          <li><a href="../integration-pack/">Builder Integration Pack</a> for the actual MCP, Local Web API, and attach proof boundaries.</li>
-          <li><a href="../">For Agents</a> for the shortest builder-facing product overview.</li>
+          <li><a href="../integration-pack/">Integration Pack</a> for the actual MCP, Local Web API, and attach proof boundaries.</li>
+          <li><a href="../">For Agents</a> for the shortest integration-facing product overview.</li>
           <li><a href="../../mcp/">MCP Provider</a> and <a href="../../local-api/">Local Web API</a> for the runtime contracts these skills are meant to protect.</li>
         </ul>
       </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,7 +65,7 @@
       <main id="main-content">
       <section class="hero">
         <div class="hero__copy">
-          <span class="hero__eyebrow">Operator first. Builder-ready only after the loop feels obvious.</span>
+          <span class="hero__eyebrow">Operator first. Integration-ready only after the loop feels obvious.</span>
           <h1>Prove your Apple Notes backup loop in one local pass.</h1>
           <p>
             Apple Notes Snapshot keeps the upstream exporter, then adds the things operators actually
@@ -101,7 +101,7 @@
             <article class="curation-card">
               <span class="eyebrow-inline">Step 3</span>
               <strong>Verify the loop, then open proof and diagnostics with context.</strong>
-              <p>Once `verify` passes, the status, logs, proof page, and builder surfaces describe a loop you already proved instead of a mystery you still need to solve.</p>
+              <p>Once `verify` passes, the status, logs, proof page, and integration surfaces describe a loop you already proved instead of a mystery you still need to solve.</p>
             </article>
           </div>
           <div class="hero__stats">
@@ -118,7 +118,7 @@
               Quickstart gets you moving and troubleshooting catches first-run snags before you drown in telemetry.
             </div>
             <div class="hero__stat">
-              <strong>Builder later</strong>
+              <strong>Integration later</strong>
               AI Diagnose, Local Web API, and MCP are upgrades, not the first thing a new operator must decode.
             </div>
           </div>
@@ -254,8 +254,8 @@
           </article>
           <article class="card card--warm">
             <h3>For Agents</h3>
-            <p>Open the builder shelf last, after the control-room contract is clear and you want the truthful Web, AI, or MCP split.</p>
-            <p><a href="./for-agents/">Open the builder guides</a></p>
+            <p>Open the integration shelf last, after the control-room contract is clear and you want the truthful Web, AI, or MCP split.</p>
+            <p><a href="./for-agents/">Open the integration guides</a></p>
           </article>
         </div>
       </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,29 +3,29 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Apple Notes Snapshot | Local-first Apple Notes backup control room for macOS</title>
+    <title>Apple Notes Snapshot | Apple Notes backup control room for macOS</title>
     <meta
       name="description"
-      content="Local-first Apple Notes backup control room for macOS with path-aware exports, visible health checks, a token-gated Local Web API, AI Diagnose, and a read-only MCP surface."
+      content="Apple Notes backup control room for macOS with path-aware exports, visible health checks, AI-assisted diagnostics, and a calmer recovery path."
     />
     <link rel="canonical" href="https://xiaojiou176-open.github.io/apple-notes-snapshot/" />
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="manifest" href="./site.webmanifest" />
     <meta name="theme-color" content="#0e7c74" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Apple Notes Snapshot | Local-first Apple Notes backup control room for macOS" />
+    <meta property="og:title" content="Apple Notes Snapshot | Apple Notes backup control room for macOS" />
     <meta
       property="og:description"
-      content="Local-first Apple Notes backup control room for macOS with path-aware exports, visible health checks, a token-gated Local Web API, AI Diagnose, and a read-only MCP surface."
+      content="Apple Notes backup control room for macOS with path-aware exports, visible health checks, AI-assisted diagnostics, and a calmer recovery path."
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot social preview showing the local-first Apple Notes backup control room" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot social preview showing the Apple Notes backup control room" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Apple Notes Snapshot | Local-first Apple Notes backup control room for macOS" />
+    <meta name="twitter:title" content="Apple Notes Snapshot | Apple Notes backup control room for macOS" />
     <meta
       name="twitter:description"
-      content="Local-first Apple Notes backup control room for macOS with path-aware exports, visible health checks, a token-gated Local Web API, AI Diagnose, and a read-only MCP surface."
+      content="Apple Notes backup control room for macOS with path-aware exports, visible health checks, AI-assisted diagnostics, and a calmer recovery path."
     />
     <meta name="twitter:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
     <link rel="stylesheet" href="./styles.css" />
@@ -39,7 +39,7 @@
         "programmingLanguage": ["Shell", "Python", "JavaScript"],
         "runtimePlatform": "macOS",
         "license": "https://github.com/xiaojiou176-open/apple-notes-snapshot/blob/main/LICENSE",
-        "description": "Local-first Apple Notes backup control room for macOS with path-aware exports, a token-gated Local Web API, AI-assisted diagnostics, a read-only MCP surface, visible health checks, and a clear recovery path."
+        "description": "Apple Notes backup control room for macOS with path-aware exports, a token-gated Local Web API, AI-assisted diagnostics, a read-only MCP surface, visible health checks, and a clear recovery path."
       }
     </script>
   </head>
@@ -48,7 +48,7 @@
     <div class="site-shell">
       <nav class="site-nav" aria-label="Primary">
         <div class="site-nav__brand">
-          <span class="site-nav__eyebrow">Local-first Apple Notes backup control room for macOS</span>
+          <span class="site-nav__eyebrow">Apple Notes backup control room for macOS</span>
           <span class="site-nav__title">Apple Notes Snapshot</span>
         </div>
         <div class="site-nav__links">
@@ -255,7 +255,7 @@
           <article class="card card--warm">
             <h3>For Agents</h3>
             <p>Open the builder shelf last, after the control-room contract is clear and you want the truthful Web, AI, or MCP split.</p>
-            <p><a href="./for-agents/">Open the builder lane</a></p>
+            <p><a href="./for-agents/">Open the builder guides</a></p>
           </article>
         </div>
       </section>

--- a/docs/local-api/index.html
+++ b/docs/local-api/index.html
@@ -6,7 +6,7 @@
     <title>Local Web API | Apple Notes Snapshot</title>
     <meta
       name="description"
-      content="Use the Apple Notes Snapshot Local Web API as a token-gated same-machine HTTP surface for status, doctor, log health, recent runs, and access policy without pretending it is a public OpenAPI."
+      content="Use the Apple Notes Snapshot Local Web API as a token-gated HTTP surface on your own machine for status, doctor, log health, recent runs, and access policy without pretending it is a public OpenAPI."
     />
     <link rel="canonical" href="https://xiaojiou176-open.github.io/apple-notes-snapshot/local-api/" />
     <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
@@ -16,16 +16,16 @@
     <meta property="og:title" content="Local Web API | Apple Notes Snapshot" />
     <meta
       property="og:description"
-      content="Token-gated same-machine HTTP surface for the Apple Notes Snapshot control room, backed by notesctl and the local state ledger."
+      content="Token-gated HTTP surface for the Apple Notes Snapshot control room on your own machine, backed by notesctl and the local state ledger."
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/local-api/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot Local Web API page for the token-gated same-machine HTTP surface" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot Local Web API page for the token-gated HTTP surface on your own machine" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Local Web API | Apple Notes Snapshot" />
     <meta
       name="twitter:description"
-      content="Token-gated same-machine HTTP surface for status, doctor, recent runs, and access policy in Apple Notes Snapshot."
+      content="Token-gated HTTP surface for status, doctor, recent runs, and access policy in Apple Notes Snapshot on your own machine."
     />
     <meta name="twitter:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
     <link rel="stylesheet" href="../styles.css" />
@@ -67,8 +67,8 @@
 
       <main id="main-content">
       <section class="page-hero">
-        <span class="page-hero__eyebrow">Same-machine, token-gated, and local-first</span>
-        <h1>Use the Local Web API when you want the Web control room plus a small same-machine HTTP surface.</h1>
+        <span class="page-hero__eyebrow">Token-gated and loopback-first</span>
+        <h1>Use the Local Web API when you want the Web control room plus a small HTTP surface on this Mac.</h1>
         <p>
           <code>./notesctl web</code> does two things at once: it serves the local browser control
           room and exposes a token-gated JSON API over the same local process. This is a real local
@@ -82,7 +82,7 @@
         <pre><code>export NOTES_SNAPSHOT_WEB_TOKEN="a-long-random-token"
 ./notesctl web --host 127.0.0.1 --port 8787</code></pre>
         <p>
-          The default fit is same-machine use on <code>127.0.0.1</code>. Keep the token gate on
+          The default fit is use on <code>127.0.0.1</code> on your own machine. Keep the token gate on
           unless you have a deliberate local-only reason to relax it.
         </p>
       </section>
@@ -91,7 +91,7 @@
         <h2>What it is good for</h2>
         <ul>
           <li><strong>Browser-backed operator workflows</strong>: open the Web console and inspect health, state layers, recent runs, and access policy</li>
-          <li><strong>Same-machine HTTP consumers</strong>: local tools that already speak HTTP can read the same local facts without screen-scraping</li>
+          <li><strong>Host-local HTTP consumers</strong>: local tools that already speak HTTP can read the same local facts without screen-scraping</li>
           <li><strong>Builder debugging</strong>: inspect token, readonly, scope, allowlist, and cooldown policy from one place</li>
         </ul>
       </section>
@@ -124,16 +124,16 @@
       </section>
 
       <section class="page-card">
-        <h2>Stable builder contract today</h2>
+        <h2>Stable integration contract today</h2>
         <ul>
-          <li><code>./notesctl help web</code> is the narrow contract summary for the browser plus Local Web API lane</li>
+          <li><code>./notesctl help web</code> is the narrow contract summary for the browser plus Local Web API surface</li>
           <li><code>./notesctl help audit</code> is the narrow contract summary for token, scope, allowlist, readonly, and rate-limit policy</li>
           <li><strong>Safest builder starting point</strong>: read endpoints plus <code>/api/access</code></li>
-          <li><strong>Action routes</strong>: same-machine operator controls first; verify the current safety boundary before you treat them as reusable automation hooks</li>
+          <li><strong>Action routes</strong>: operator controls on your own machine come first; verify the current safety boundary before you treat them as reusable automation hooks</li>
         </ul>
         <p>
           Need the host matrix and copyable setup examples? Open the
-          <a href="../for-agents/integration-pack/">Builder Integration Pack</a>.
+          <a href="../for-agents/integration-pack/">Integration Pack</a>.
         </p>
         <p>
           Need the repo-owned post-attach checklist? Start with
@@ -143,7 +143,7 @@
       </section>
 
       <section class="page-card">
-        <h2>Minimal same-machine request shape</h2>
+        <h2>Minimal request shape on your own machine</h2>
         <pre><code>curl -H "Authorization: Bearer $NOTES_SNAPSHOT_WEB_TOKEN" \
   http://127.0.0.1:8787/api/status
 
@@ -154,7 +154,7 @@ curl -H "Authorization: Bearer $NOTES_SNAPSHOT_WEB_TOKEN" \
       <section class="page-card">
         <h2>How it differs from MCP</h2>
         <ul>
-          <li><strong>Local Web API</strong>: browser and same-machine HTTP surface behind <code>./notesctl web</code></li>
+          <li><strong>Local Web API</strong>: browser and HTTP surface behind <code>./notesctl web</code> on your own machine</li>
           <li><strong>MCP</strong>: stdio-first host-to-tooling contract behind <code>./notesctl mcp</code></li>
           <li><strong>Shared truth</strong>: both reuse the same deterministic local state surfaces</li>
         </ul>
@@ -176,7 +176,8 @@ curl -H "Authorization: Bearer $NOTES_SNAPSHOT_WEB_TOKEN" \
       </main>
 
       <footer class="footer">
-        Keep the naming honest: local control room first, local Web API second, public platform claims out of scope.
+        Keep the naming honest: control room first, Local Web API when you need it, public
+        platform claims out of scope.
       </footer>
     </div>
   </body>

--- a/docs/mcp/index.html
+++ b/docs/mcp/index.html
@@ -110,7 +110,7 @@
         </ul>
         <p>
           Need host-by-host status and copyable examples? Open the
-          <a href="../for-agents/integration-pack/">Builder Integration Pack</a>.
+          <a href="../for-agents/integration-pack/">Integration Pack</a>.
         </p>
         <p>
           Need the repo-owned attach checklist? Use
@@ -211,12 +211,12 @@
         <h2>How MCP differs from the local Web API</h2>
         <ul>
           <li><strong>MCP</strong>: stdio-first, host-to-tooling contract for MCP-aware agents</li>
-          <li><strong>Local Web API</strong>: token-gated browser and same-machine HTTP surface behind <code>./notesctl web</code></li>
+          <li><strong>Local Web API</strong>: token-gated browser and host-local HTTP surface behind <code>./notesctl web</code></li>
           <li><strong>Shared truth</strong>: both sit on top of the same repo-owned status, doctor, log-health, aggregate, and access-policy surfaces</li>
           <li><strong>Still not claimed</strong>: neither surface becomes a public OpenAPI or hosted control plane</li>
         </ul>
         <p>
-          If your workflow already runs through the local Web console or same-machine HTTP clients,
+          If your workflow already runs through the local Web console or host-local HTTP clients,
           open the <a href="../local-api/">Local Web API guide</a> next.
         </p>
       </section>

--- a/docs/media/30-second-overview.md
+++ b/docs/media/30-second-overview.md
@@ -10,7 +10,7 @@ It keeps the upstream exporter, then adds a local control room around it:
 - log rotation and log-health summaries
 - state files and metrics
 - an optional local Web console
-- a token-gated Local Web API for same-machine browser/API workflows
+- a token-gated Local Web API for host-local browser/API workflows
 - AI Diagnose as an advisory explanation layer
 - a read-only MCP Provider for MCP-aware coding agents
 
@@ -22,4 +22,5 @@ Need the reusable compare card or the 10-second run-flow demo? Open the public
 share kit in `docs/media/share-kit/`.
 
 It is not a cloud service, not a team notes platform, not a public OpenAPI,
-and not a two-way sync engine. It is a local-first snapshot workflow for macOS.
+and not a two-way sync engine. It is a macOS snapshot workflow with a local
+control room.

--- a/docs/media/30-second-overview/index.html
+++ b/docs/media/30-second-overview/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/media/30-second-overview/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot 30-second overview card for the local-first Apple Notes backup control room" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot 30-second overview card for the Apple Notes backup control room" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Apple Notes Snapshot in 30 seconds" />
     <meta
@@ -77,14 +77,14 @@
       <section class="page-card">
         <h2>What it is</h2>
         <p>
-          A local-first macOS workflow for exporting Apple Notes on a schedule and keeping the
+          A macOS backup workflow for exporting Apple Notes on a schedule and keeping the
           workflow observable. The runtime config lives in
           <code>config/notes_snapshot.env</code>, so you can review where snapshots will land
           before the first run.
         </p>
         <ul>
           <li>AI Diagnose for calmer operator explanations</li>
-          <li>Local Web API for token-gated same-machine browser/API workflows</li>
+          <li>Local Web API for token-gated browser/API workflows on this Mac</li>
           <li>Read-only MCP Provider for MCP-aware coding agents</li>
         </ul>
       </section>

--- a/docs/media/external-launch-prep/index.html
+++ b/docs/media/external-launch-prep/index.html
@@ -148,8 +148,8 @@
         <h2>Truthful snippets you can reuse</h2>
         <ul>
           <li><strong>One-line pitch</strong>: Use upstream for the engine. Use this repo for the local control room.</li>
-          <li><strong>30-second pitch</strong>: Apple Notes Snapshot is a local-first macOS backup control room that keeps the upstream exporter, then adds scheduling, health checks, a token-gated Local Web API, AI Diagnose, and a read-only MCP surface.</li>
-          <li><strong>Builder-heavy pitch</strong>: The truthful builder entry points today are <code>notesctl</code>, the same-machine Local Web API, and the read-only stdio-first MCP surface. It is not a public API or SDK platform.</li>
+          <li><strong>30-second pitch</strong>: Apple Notes Snapshot is a macOS backup control room that keeps the upstream exporter, then adds scheduling, health checks, AI diagnostics, and a calmer recovery path.</li>
+          <li><strong>Integration-heavy pitch</strong>: The truthful integration entry points today are <code>notesctl</code>, the host-local web/API lane, and the read-only MCP surface. They are support surfaces, not a public API or SDK platform.</li>
           <li><strong>Support routing line</strong>: Questions and setup blockers go to Q&amp;A; public updates and release notes should still point people back to Support and Community.</li>
         </ul>
       </section>

--- a/docs/media/founder-note.md
+++ b/docs/media/founder-note.md
@@ -20,7 +20,7 @@ That operations layer now includes three truthful optional surfaces on top of
 the same local substrate:
 
 - AI Diagnose for calmer operator explanations
-- Local Web API for token-gated same-machine browser/API reads
+- Local Web API for token-gated browser/API reads on this Mac
 - MCP Provider for read-only agent access
 
 The shortest public version is:

--- a/docs/media/founder-note/index.html
+++ b/docs/media/founder-note/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/media/founder-note/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot founder note card for the local-first Apple Notes backup control room" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot founder note card for the Apple Notes backup control room" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Why Apple Notes Snapshot exists" />
     <meta
@@ -90,7 +90,7 @@
         </p>
         <ul>
           <li>AI Diagnose for calmer operator explanations</li>
-          <li>Local Web API for token-gated same-machine browser/API reads</li>
+          <li>Local Web API for token-gated browser/API reads on this Mac</li>
           <li>MCP Provider for read-only agent access</li>
         </ul>
       </section>

--- a/docs/media/share-kit.md
+++ b/docs/media/share-kit.md
@@ -10,7 +10,7 @@ Use upstream for the engine. Use this repo for the local control room.
 Optional truthful hooks you can add when the audience cares:
 
 - AI Diagnose = operator next-step explanation layer
-- Local Web API = token-gated same-machine browser/API lane
+- Local Web API = token-gated host-local browser/API surface
 - MCP Provider = read-only agent-facing substrate
 
 ## 10-second demo

--- a/docs/media/share-kit/index.html
+++ b/docs/media/share-kit/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/media/share-kit/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot share kit card for the local-first Apple Notes backup control room" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot share kit card for the Apple Notes backup control room" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Apple Notes Snapshot share kit" />
     <meta
@@ -75,7 +75,7 @@
         </p>
         <ul>
           <li><strong>AI Diagnose</strong>: operator next-step explanation layer</li>
-          <li><strong>Local Web API</strong>: token-gated same-machine browser/API lane</li>
+          <li><strong>Local Web API</strong>: token-gated browser/API lane on this Mac</li>
           <li><strong>MCP Provider</strong>: read-only agent-facing substrate</li>
         </ul>
       </section>
@@ -136,11 +136,11 @@
         <h2>Copy-ready snippets</h2>
         <p>Reuse these when you need truthful public copy without inventing a bigger platform story.</p>
         <h3>Repository description</h3>
-        <pre><code>Local-first Apple Notes backup control room for macOS with AI diagnostics, a token-gated local Web API, a read-only MCP surface, and builder-friendly entry points for Codex and Claude Code-style local workflows.</code></pre>
+        <pre><code>Apple Notes backup control room for macOS with AI diagnostics, a calmer recovery path, and optional coding-agent access for Codex and Claude Code-style workflows.</code></pre>
         <h3>Release or announcement blurb</h3>
-        <pre><code>Apple Notes Snapshot keeps the upstream exporter, then adds scheduling, health checks, a token-gated Local Web API, AI Diagnose, and a read-only MCP surface so the same local backup facts stay visible to humans and coding agents.</code></pre>
+        <pre><code>Apple Notes Snapshot keeps the upstream exporter, then adds scheduling, health checks, AI diagnostics, and read-only builder access so the same backup facts stay visible to humans and coding agents.</code></pre>
         <h3>Short social teaser</h3>
-        <pre><code>Use upstream for the engine. Use this repo for the local control room. Apple Notes Snapshot adds scheduling, health checks, and truthful local builder surfaces without pretending to be a hosted notes platform.</code></pre>
+        <pre><code>Use upstream for the engine. Use this repo for the control room. Apple Notes Snapshot adds scheduling, health checks, and trustworthy integration access without pretending to be a hosted notes platform.</code></pre>
       </section>
       </main>
 

--- a/docs/proof/index.html
+++ b/docs/proof/index.html
@@ -6,7 +6,7 @@
     <title>Proof and trust boundary | Apple Notes Snapshot</title>
     <meta
       name="description"
-      content="See the Apple Notes Snapshot proof stack: repo-owned gates, GitHub-controlled release evidence, live Web and MCP surface checks, and the current same-machine boundary."
+      content="See the Apple Notes Snapshot proof stack: repo-owned gates, GitHub-controlled release evidence, live Web and MCP surface checks, and the current access boundary."
     />
     <link rel="canonical" href="https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/" />
     <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
@@ -16,7 +16,7 @@
     <meta property="og:title" content="Proof and trust boundary | Apple Notes Snapshot" />
     <meta
       property="og:description"
-      content="See the repo-owned gates, GitHub-controlled release evidence, live Web and MCP checks, and the current same-machine boundary for Apple Notes Snapshot."
+      content="See the repo-owned gates, GitHub-controlled release evidence, live Web and MCP checks, and the current access boundary for Apple Notes Snapshot."
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
@@ -25,7 +25,7 @@
     <meta name="twitter:title" content="Proof and trust boundary | Apple Notes Snapshot" />
     <meta
       name="twitter:description"
-      content="See the Apple Notes Snapshot proof stack: repo gates, release evidence, live Web and MCP checks, and the current same-machine boundary."
+      content="See the Apple Notes Snapshot proof stack: repo gates, release evidence, live Web and MCP checks, and the current access boundary."
     />
     <meta name="twitter:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
     <link rel="stylesheet" href="../styles.css" />
@@ -68,7 +68,7 @@
         <h1>See why this control room is worth trusting without reading every workflow by hand.</h1>
         <p>
           This page collects the shortest truthful evidence trail for Apple Notes Snapshot. It
-          separates repo-owned gates, GitHub-controlled delivery facts, live same-machine surface
+          separates repo-owned gates, GitHub-controlled delivery facts, live Web/API/MCP surface
           checks, and the places where a real host or macOS permission prompt still becomes the
           final boundary.
         </p>
@@ -87,8 +87,8 @@
         </article>
         <article class="signal-card">
           <span class="eyebrow-inline">Ledger 3</span>
-          <strong>Live same-machine proof</strong>
-          <p>Web and MCP are real, but they stay local and read-only-first in spirit.</p>
+          <strong>Live access proof</strong>
+          <p>Web and MCP are real, but they stay tightly bounded and read-only-first in spirit.</p>
         </article>
         <article class="signal-card">
           <span class="eyebrow-inline">Ledger 4</span>
@@ -109,10 +109,10 @@
           </p>
         </article>
         <article class="callout">
-          <span class="eyebrow-inline">Same-machine boundary</span>
+          <span class="eyebrow-inline">Access boundary</span>
           <h3>Web and MCP are real, but they do not become a hosted platform.</h3>
           <p>
-            The Local Web API stays token-gated and same-machine. MCP stays stdio-first and
+            The Local Web API stays token-gated and machine-bounded. MCP stays stdio-first and
             read-only-first. The repo still does not claim a public OpenAPI, hosted API, or
             write-capable agent platform.
           </p>
@@ -150,7 +150,7 @@
       </section>
 
       <section class="page-card">
-        <h2>Live same-machine proof</h2>
+        <h2>Live access proof</h2>
         <ul>
           <li><strong>Local Web API</strong>: token-gated requests to <code>/api/health</code>, <code>/api/access</code>, and <code>/api/status</code> were re-run against a local <code>./notesctl web</code> process.</li>
           <li><strong>MCP</strong>: stdio <code>initialize</code> and <code>tools/list</code> were re-run against <code>./notesctl mcp</code>, confirming the read-only-first tool surface still advertises the current contract.</li>
@@ -175,9 +175,9 @@
       <section class="page-card page-card--warm">
         <h2>What this page does not do for you</h2>
         <p>
-          This page is a trust ledger, not a shortcut around the local-first reality. It does not
+          This page is a trust ledger, not a shortcut around the real access boundary. It does not
           replace Quickstart, it does not skip Apple Notes permissions, and it does not turn the
-          same-machine Web/API/MCP surfaces into a hosted platform promise.
+          Web/API/MCP surfaces on your machine into a hosted platform promise.
         </p>
       </section>
 
@@ -194,8 +194,8 @@
       </main>
 
       <footer class="footer">
-        Proof here means evidence plus boundary, not hype. The control room stays local-first, the
-        Web/API lane stays same-machine and token-gated, and MCP stays read-only-first unless the
+        Proof here means evidence plus boundary, not hype. The control room stays user-controlled, the
+        Web/API lane stays token-gated on your machine, and MCP stays read-only-first unless the
         repo proves a different contract in a future tag.
       </footer>
     </div>

--- a/docs/quickstart/index.html
+++ b/docs/quickstart/index.html
@@ -20,7 +20,7 @@
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot quickstart card showing the local-first Apple Notes backup control room" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot quickstart card showing the Apple Notes backup control room" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Run Apple Notes Snapshot in 3 steps on macOS" />
     <meta
@@ -198,7 +198,7 @@ PYTHON_BIN=./.runtime-cache/dev/venv/bin/python scripts/checks/ci_gate.sh</code>
 ./notesctl web</code></pre>
         <p>
           If your workflow is browser- or HTTP-shaped after setup, the same process also exposes
-          the token-gated <a href="../local-api/">Local Web API</a> for same-machine reads.
+          the token-gated <a href="../local-api/">Local Web API</a> for host-local reads.
         </p>
       </section>
 

--- a/docs/releases/index.html
+++ b/docs/releases/index.html
@@ -76,7 +76,7 @@
       <section class="timeline-grid">
         <article class="timeline-card timeline-card--featured">
           <span class="eyebrow-inline">Current surface</span>
-          <h3>v0.1.12 tightens the builder lane without changing the operator-first story.</h3>
+          <h3>v0.1.12 tightens the integration lane without changing the operator-first story.</h3>
           <p>The latest public tag now packages the named-host attach proof, the public skills packet, and the MCPB delivery lane as a second shelf around the same control room.</p>
         </article>
         <article class="timeline-card">

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -2,7 +2,7 @@
 
 ## What this project is
 
-Apple Notes Snapshot is a local-first macOS workflow that wraps the upstream
+Apple Notes Snapshot is a macOS backup workflow that wraps the upstream
 `notes-exporter` project with scheduling, health checks, logs, and an optional
 local Web console.
 

--- a/docs/releases/v0.1.0/index.html
+++ b/docs/releases/v0.1.0/index.html
@@ -6,7 +6,7 @@
     <title>v0.1.0 release notes | Apple Notes Snapshot</title>
     <meta
       name="description"
-      content="Release notes for Apple Notes Snapshot v0.1.0, the initial public launch of the local-first Apple Notes snapshot workflow."
+      content="Release notes for Apple Notes Snapshot v0.1.0, the initial public launch of the Apple Notes backup workflow."
     />
     <link rel="canonical" href="https://xiaojiou176-open.github.io/apple-notes-snapshot/releases/v0.1.0/" />
     <link rel="icon" href="../../favicon.svg" type="image/svg+xml" />
@@ -16,7 +16,7 @@
     <meta property="og:title" content="v0.1.0 release notes | Apple Notes Snapshot" />
     <meta
       property="og:description"
-      content="Release notes for Apple Notes Snapshot v0.1.0, the initial public launch of the local-first Apple Notes snapshot workflow."
+      content="Release notes for Apple Notes Snapshot v0.1.0, the initial public launch of the Apple Notes backup workflow."
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/releases/v0.1.0/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
@@ -25,7 +25,7 @@
     <meta name="twitter:title" content="v0.1.0 release notes | Apple Notes Snapshot" />
     <meta
       name="twitter:description"
-      content="Release notes for Apple Notes Snapshot v0.1.0, the initial public launch of the local-first Apple Notes snapshot workflow."
+      content="Release notes for Apple Notes Snapshot v0.1.0, the initial public launch of the Apple Notes backup workflow."
     />
     <meta name="twitter:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
     <link rel="stylesheet" href="../../styles.css" />
@@ -58,7 +58,7 @@
         <span class="page-hero__eyebrow">Initial public launch</span>
         <h1>v0.1.0 introduced Apple Notes Snapshot as a public project.</h1>
         <p>
-          Apple Notes Snapshot is a local-first macOS workflow that wraps the upstream
+          Apple Notes Snapshot is a macOS backup workflow that wraps the upstream
           <code>notes-exporter</code> project with scheduling, health checks, logs, and an optional
           local Web console.
         </p>

--- a/docs/releases/v0.1.6.md
+++ b/docs/releases/v0.1.6.md
@@ -10,7 +10,7 @@ public builder-proof story.
 - `./notesctl ai-diagnose` now routes model invocation through a local Switchyard runtime instead of snapshot-owned direct OpenAI/Ollama wiring
 - deterministic fallback still holds when the Switchyard runtime is disabled, missing, or unreachable
 - AI Diagnose config/help/docs now explain the local Switchyard runtime boundary and the current best-supported live path (`gemini` BYOK)
-- the Builder Integration Pack now treats Codex and Claude Code as generic-path documented hosts, not attach-proven hosts
+- the Integration Pack now treats Codex and Claude Code as generic-path documented hosts, not attach-proven hosts
 
 ## Why it matters
 
@@ -21,7 +21,7 @@ but the model power cord now runs through Switchyard.
 ## Keep going
 
 - AI Diagnose: <https://xiaojiou176-open.github.io/apple-notes-snapshot/ai-diagnose/>
-- Builder Integration Pack: <https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/integration-pack/>
+- Integration Pack: <https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/integration-pack/>
 - Local Web API: <https://xiaojiou176-open.github.io/apple-notes-snapshot/local-api/>
 - MCP Provider: <https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/>
 - External launch prep: <https://xiaojiou176-open.github.io/apple-notes-snapshot/media/external-launch-prep/>

--- a/docs/releases/v0.1.6/index.html
+++ b/docs/releases/v0.1.6/index.html
@@ -69,7 +69,7 @@
           <li><code>./notesctl ai-diagnose</code> now routes model calls through a local Switchyard runtime.</li>
           <li>Deterministic fallback still works when the Switchyard runtime is unavailable or misconfigured.</li>
           <li>AI Diagnose docs/help/config now explain the local Switchyard boundary and current Gemini BYOK path.</li>
-          <li>The Builder Integration Pack now treats Codex and Claude Code as generic-path documented hosts, not attach-proven hosts.</li>
+          <li>The Integration Pack now treats Codex and Claude Code as generic-path documented hosts, not attach-proven hosts.</li>
         </ul>
       </section>
 
@@ -86,7 +86,7 @@
         <h2>Keep going</h2>
         <ul>
           <li><a href="../../ai-diagnose/">AI Diagnose</a></li>
-          <li><a href="../../for-agents/integration-pack/">Builder Integration Pack</a></li>
+          <li><a href="../../for-agents/integration-pack/">Integration Pack</a></li>
           <li><a href="../../local-api/">Local Web API</a></li>
           <li><a href="../../mcp/">MCP Provider</a></li>
           <li><a href="../../media/external-launch-prep/">External launch prep</a></li>

--- a/docs/releases/v0.1.7.md
+++ b/docs/releases/v0.1.7.md
@@ -2,7 +2,7 @@
 
 ## What changed after v0.1.6
 
-This release turns the new builder-facing packaging work into tagged truth.
+This release turns the new integration-facing packaging work into tagged truth.
 
 ## Highlights
 
@@ -26,5 +26,5 @@ owner can press.
 - Codex starter pack: <https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/codex-starter-pack/>
 - Claude Code starter pack: <https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/claude-code-starter-pack/>
 - Public skills pack: <https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/public-skills/>
-- Builder Integration Pack: <https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/integration-pack/>
+- Integration Pack: <https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/integration-pack/>
 - External launch prep: <https://xiaojiou176-open.github.io/apple-notes-snapshot/media/external-launch-prep/>

--- a/docs/releases/v0.1.7/index.html
+++ b/docs/releases/v0.1.7/index.html
@@ -90,7 +90,7 @@
           <li><a href="../../for-agents/codex-starter-pack/">Codex starter pack</a></li>
           <li><a href="../../for-agents/claude-code-starter-pack/">Claude Code starter pack</a></li>
           <li><a href="../../for-agents/public-skills/">Public skills pack</a></li>
-          <li><a href="../../for-agents/integration-pack/">Builder Integration Pack</a></li>
+          <li><a href="../../for-agents/integration-pack/">Integration Pack</a></li>
           <li><a href="../../media/external-launch-prep/">External launch prep</a></li>
         </ul>
       </section>

--- a/docs/releases/v0.1.9.md
+++ b/docs/releases/v0.1.9.md
@@ -8,8 +8,8 @@ proves it cleanly.”
 ## Highlights
 
 - added a public proof page for repo-side gates, GitHub-controlled evidence,
-  live same-machine surfaces, and trust boundaries
-- tightened the front door so the control-room story stays first and builder
+  live host-local surfaces, and trust boundaries
+- tightened the front door so the control-room story stays first and integration
   surfaces stay second-lane
 - hardened launchd install against disabled-label host state
 - stopped lock-contention skip paths from polluting the state ledger as

--- a/docs/releases/v0.1.9/index.html
+++ b/docs/releases/v0.1.9/index.html
@@ -67,8 +67,8 @@
       <section class="page-card">
         <h2>Highlights</h2>
         <ul>
-          <li>Added a public proof page for repo-side gates, GitHub-controlled evidence, live same-machine surfaces, and trust boundaries.</li>
-          <li>Tightened the front door so the control-room story stays first and builder surfaces stay second-lane.</li>
+          <li>Added a public proof page for repo-side gates, GitHub-controlled evidence, live host-local surfaces, and trust boundaries.</li>
+          <li>Tightened the front door so the control-room story stays first and integration surfaces stay second-lane.</li>
           <li>Hardened launchd install against disabled-label host state.</li>
           <li>Stopped lock-contention skip paths from polluting the state ledger as <code>aborted</code>.</li>
         </ul>

--- a/docs/roadmap/index.html
+++ b/docs/roadmap/index.html
@@ -65,7 +65,7 @@
       <section class="cards section">
         <article class="card">
           <h3>Now</h3>
-          <p>The public launch surface, docs site, releases, discussions, release history, support routing, examples, troubleshooting, the path-first quickstart, a token-gated Local Web API, an opt-in AI Diagnose sidecar, and a read-only-first MCP provider are in place.</p>
+          <p>The public launch surface, docs site, releases, discussions, release history, support routing, examples, troubleshooting, the path-first quickstart, a token-gated Local Web API, an opt-in AI Diagnose layer, and a read-only-first MCP provider are in place.</p>
         </article>
         <article class="card">
           <h3>Next</h3>
@@ -73,7 +73,7 @@
         </article>
         <article class="card">
           <h3>Later</h3>
-          <p>More operational polish only if it stays reviewable, local-first, and honest about scope.</p>
+          <p>More operational polish only if it stays reviewable, host-local, and honest about scope.</p>
         </article>
       </section>
 
@@ -83,7 +83,7 @@
           <li>More example workflows for common Apple Notes export habits after the first successful run</li>
           <li>More troubleshooting runbooks for launchd edge cases, permission prompts, and path surprises</li>
           <li>Clearer AI Diagnose guidance and summary surfaces around recent runs, failure reasons, and operator next steps</li>
-          <li>Sharper builder-facing docs around the CLI substrate, Local Web API, MCP surface, and where agent integrations truthfully begin today</li>
+          <li>Sharper integration-facing docs around the CLI substrate, Local Web API, MCP surface, and where agent integrations truthfully begin today</li>
           <li>Better screenshots and short clips when the runtime surface grows in meaningful ways</li>
           <li>Issue and discussion triage refinements based on real user traffic</li>
           <li>Read-first MCP polish, plus any future guarded write-actions only when the current read-only surface proves useful</li>

--- a/docs/security/index.html
+++ b/docs/security/index.html
@@ -6,7 +6,7 @@
     <title>Review Apple Notes Snapshot security and privacy | Security</title>
     <meta
       name="description"
-      content="Review Apple Notes Snapshot security and privacy boundaries, including local-first behavior, optional Web token handling, and private vulnerability reporting."
+      content="Review Apple Notes Snapshot security and privacy boundaries, including local runtime behavior, optional Web token handling, and private vulnerability reporting."
     />
     <link rel="canonical" href="https://xiaojiou176-open.github.io/apple-notes-snapshot/security/" />
     <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
@@ -16,16 +16,16 @@
     <meta property="og:title" content="Security and privacy | Apple Notes Snapshot" />
     <meta
       property="og:description"
-      content="Review Apple Notes Snapshot security and privacy boundaries, including local-first behavior, optional Web token handling, and private vulnerability reporting."
+      content="Review Apple Notes Snapshot security and privacy boundaries, including local runtime behavior, optional Web token handling, and private vulnerability reporting."
     />
     <meta property="og:url" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/security/" />
     <meta property="og:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
-    <meta property="og:image:alt" content="Apple Notes Snapshot security and privacy card for the local-first Apple Notes backup control room" />
+    <meta property="og:image:alt" content="Apple Notes Snapshot security and privacy card for the Apple Notes backup control room" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Review Apple Notes Snapshot security and privacy" />
     <meta
       name="twitter:description"
-      content="Review Apple Notes Snapshot security and privacy boundaries, including local-first behavior, optional Web token handling, and private vulnerability reporting."
+      content="Review Apple Notes Snapshot security and privacy boundaries, including local runtime behavior, optional Web token handling, and private vulnerability reporting."
     />
     <meta name="twitter:image" content="https://xiaojiou176-open.github.io/apple-notes-snapshot/assets/social-preview.png" />
     <link rel="stylesheet" href="../styles.css" />
@@ -89,7 +89,7 @@
       <section class="page-card">
         <h2>Privacy model in one paragraph</h2>
         <p>
-          Apple Notes Snapshot is local-first. Your notes stay in your Apple Notes account and in the
+          Apple Notes Snapshot runs locally by design. Your notes stay in your Apple Notes account and in the
           export destination you choose. The repository does not describe a hosted backend, an
           analytics pipeline, or a cloud account model. The optional Web console and Local Web API
           are local by default and should remain local unless you have a deliberate reason to expose

--- a/docs/site.webmanifest
+++ b/docs/site.webmanifest
@@ -2,7 +2,7 @@
   "id": "/apple-notes-snapshot/",
   "name": "Apple Notes Snapshot",
   "short_name": "Notes Snapshot",
-  "description": "Local-first Apple Notes backup control room for macOS with a token-gated Local Web API, AI Diagnose, and a read-only MCP surface.",
+  "description": "Apple Notes backup control room for macOS with a token-gated Local Web API, AI Diagnose, and a read-only MCP surface.",
   "start_url": "/apple-notes-snapshot/",
   "scope": "/apple-notes-snapshot/",
   "display": "standalone",

--- a/docs/troubleshooting/index.html
+++ b/docs/troubleshooting/index.html
@@ -105,7 +105,7 @@ config/notes_snapshot.env</code></pre>
           <li>Keep it on loopback by default</li>
           <li>Set `NOTES_SNAPSHOT_WEB_TOKEN` before enabling it</li>
           <li>Use the doctor and access-policy surfaces before widening the bind address</li>
-          <li>Read the <a href="../local-api/">Local Web API guide</a> if your same-machine workflow also depends on the JSON endpoints</li>
+          <li>Read the <a href="../local-api/">Local Web API guide</a> if your host-local workflow also depends on the JSON endpoints</li>
         </ul>
       </section>
 

--- a/tests/unit/test_public_frontdoor_contract.py
+++ b/tests/unit/test_public_frontdoor_contract.py
@@ -24,34 +24,34 @@ class PublicFrontDoorContractTests(unittest.TestCase):
             f"expected {earlier!r} to appear before {later!r}",
         )
 
-    def test_readme_keeps_run_install_verify_before_builder_lane(self):
+    def test_readme_keeps_run_install_verify_before_integration_lane(self):
         self.assertIn("## Start with Run -> Install -> Verify", self.readme)
         self.assertIn("[Start the 3-step quickstart]", self.readme)
         self.assertIn("[Open the proof page]", self.readme)
         self.assertIn("[Get support or routing help]", self.readme)
-        self.assertIn("## Builder and maintainer lanes after the operator path", self.readme)
-        self.assertIn("Secondary builder reads after the first healthy loop:", self.readme)
+        self.assertIn("## Integration and maintainer routes after the operator path", self.readme)
+        self.assertIn("Secondary integration reads after the first healthy loop:", self.readme)
         self.assertIn("[Distribution and listing boundaries](./DISTRIBUTION.md)", self.readme)
-        self.assertIn("[For Codex / Claude Code builders]", self.readme)
+        self.assertIn("[For Codex / Claude Code integrations]", self.readme)
 
         self.assert_order(
             self.readme,
             "## Start with Run -> Install -> Verify",
-            "## Builder and maintainer lanes after the operator path",
+            "## Integration and maintainer routes after the operator path",
         )
         self.assert_order(
             self.readme,
             "[Get support or routing help]",
-            "Secondary builder reads after the first healthy loop:",
+            "Secondary integration reads after the first healthy loop:",
         )
         self.assert_order(
             self.readme,
-            "Secondary builder reads after the first healthy loop:",
-            "[For Codex / Claude Code builders]",
+            "Secondary integration reads after the first healthy loop:",
+            "[For Codex / Claude Code integrations]",
         )
 
-    def test_docs_front_door_keeps_first_success_ctas_ahead_of_builder_lane(self):
-        self.assertIn("Operator first. Builder-ready only after the loop feels obvious.", self.docs_index)
+    def test_docs_front_door_keeps_first_success_ctas_ahead_of_integration_lane(self):
+        self.assertIn("Operator first. Integration-ready only after the loop feels obvious.", self.docs_index)
         self.assertIn("Start the 3-step quickstart", self.docs_index)
         self.assertIn("First-run troubleshooting", self.docs_index)
         self.assertIn("Open the proof page", self.docs_index)
@@ -59,8 +59,8 @@ class PublicFrontDoorContractTests(unittest.TestCase):
         self.assertIn(">Install the loop so backups stop depending on your memory.<", self.docs_index)
         self.assertIn(">Verify the loop, then open proof and diagnostics with context.<", self.docs_index)
         self.assertIn(">For Agents<", self.docs_index)
-        self.assertIn("Open the builder lane", self.docs_index)
-        self.assertIn("Open the builder shelf last", self.docs_index)
+        self.assertIn("Open the integration guides", self.docs_index)
+        self.assertIn("Open the integration shelf last", self.docs_index)
         self.assertIn("Distribution boundary", self.docs_index)
         self.assertIn("Open the distribution ledger", self.docs_index)
         self.assertIn(
@@ -71,12 +71,12 @@ class PublicFrontDoorContractTests(unittest.TestCase):
         self.assert_order(
             self.docs_index,
             "Start the 3-step quickstart",
-            "Open the builder lane",
+            "Open the integration guides",
         )
         self.assert_order(
             self.docs_index,
             "Open the proof page",
-            "Open the builder lane",
+            "Open the integration guides",
         )
         self.assert_order(
             self.docs_index,
@@ -92,7 +92,7 @@ class PublicFrontDoorContractTests(unittest.TestCase):
     def test_web_console_preserves_the_same_first_success_spine(self):
         self.assertIn('data-i18n="ui.operatorLane">Run -> Install -> Verify</h2>', self.web_index)
         self.assertIn(
-            'Run one snapshot, install launchd, then verify the loop before you read deeper diagnostics or builder lanes.',
+            'Run one snapshot, install launchd, then verify the loop before you read deeper diagnostics or integration surfaces.',
             self.web_index,
         )
         self.assertIn("Open the <a href=\"https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/\">quickstart</a>", self.web_index)

--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
         <div class="brand">
           <div class="badge" data-i18n="ui.badgeLocal">LOCAL</div>
           <h1 data-i18n="ui.title">Notes Snapshot Console</h1>
-          <p data-i18n="ui.heroSummary">Run one snapshot, install launchd, then verify the loop before you read deeper diagnostics or builder lanes.</p>
+          <p data-i18n="ui.heroSummary">Run one snapshot, install launchd, then verify the loop before you read deeper diagnostics or integration surfaces.</p>
         </div>
         <div class="actions">
           <label class="locale-picker" for="locale-switcher">


### PR DESCRIPTION
## Summary
- tighten public-facing docs, release notes, and media copy so the repo leads with product/use/clear start paths
- demote implementation-heavy wording like local-first/same-machine/sidecar from public-facing surfaces
- keep truthful boundaries while avoiding self-undermining front-door language

## Verification Evidence
- `git diff --check` -> exit 0

## Remaining Blockers
- branch protection requires PR checks before merge
